### PR TITLE
resolves result selection bug

### DIFF
--- a/R/mod_result_selection.R
+++ b/R/mod_result_selection.R
@@ -90,11 +90,15 @@ mod_result_selection_server <- function(id) {
       shiny::bindEvent(input$dataset)
 
     create_datetimes <- shiny::reactive({
-      x <- shiny::req(input$scenario)
+      ds <- shiny::req(input$dataset)
+      sc <- shiny::req(input$scenario)
 
       result_sets() |>
         shiny::req() |>
-        dplyr::filter(.data[["scenario"]] == x) |>
+        dplyr::filter(
+          .data[["dataset"]] == ds,
+          .data[["scenario"]] == sc
+        ) |>
         dplyr::pull(.data[["create_datetime"]]) |>
         unique() |>
         sort() |>


### PR DESCRIPTION
The result selection page had a slight bug where if you created multiple different model runs with the same scenario across datasets the list of dates was not filtering on the dataset, just on the scenario. This resulted in invalid values being displayed in the create datetime drop down, so the app showed no results