### PR TITLE
Add labels to treatment specialty codes

### DIFF
--- a/R/mod_principal_detailed.R
+++ b/R/mod_principal_detailed.R
@@ -141,7 +141,7 @@ mod_principal_detailed_server <- function(id, selected_data, selected_site) {
               \(x) dplyr::if_else(is.na(x), .data$agg, .data$Description)
             ),
           ) |>
-          dplyr::select("Description", dplyr::everything(), -"agg") |>
+          dplyr::select("sex", "Description", dplyr::everything(), -"agg") |>
           dplyr::rename("agg" = "Description")
       }
 

--- a/manifest.json
+++ b/manifest.json
@@ -5200,7 +5200,7 @@
       "checksum": "89e01a142b1a6327f5b39b96d1a8ff13"
     },
     "R/mod_principal_detailed.R": {
-      "checksum": "c770e1450caa09e75e5ec803c29552b4"
+      "checksum": "63a824c24906c8e1c9c6498ad0a5cb7e"
     },
     "R/mod_principal_high_level.R": {
       "checksum": "68cddef512ec1f98f29d6e9e55801964"

--- a/tests/testthat/test-mod_principal_detailed.R
+++ b/tests/testthat/test-mod_principal_detailed.R
@@ -21,8 +21,8 @@ aggregations_age_group_expected <- tibble::tribble(
 
 aggregations_tretspef_expected <- tibble::tribble(
   ~sex, ~tretspef, ~baseline, ~principal, ~median, ~lwr_ci, ~upr_ci,
-  1, "100", 900, 800, 850, 825, 875,
-  1, "300", 650, 550, 600, 625, 650
+  1, "100: General Surgery", 900, 800, 850, 825, 875,
+  1, "300: General Internal Medicine", 650, 550, 600, 625, 650
 )
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #101.

Rather than seeing '101' in the 'activity in detail' table when grouped by treatment specialty, we now see'101: General Surgery', etc, based on the json lookup of codes to names from the [NHS Data Dictionary](https://www.datadictionary.nhs.uk/supporting_information/main_specialty_and_treatment_function_codes_table.html).