### PR TITLE
Avoid sourcing report functions if they're available already

### DIFF
--- a/inst/report.Rmd
+++ b/inst/report.Rmd
@@ -16,7 +16,15 @@ params:
 #| echo: false
 
 knitr::opts_chunk$set(error = TRUE, echo = FALSE)
-source(here::here("R", "fct_report.R"), local = knitr::knit_global())
+
+# Check if fct_report functions are loaded by seeing if one exists in the env
+# (allows for both local and remote rendering)
+if (!exists("mod_info_home_download_json")) {
+  source(
+    here::here("R", "fct_report.R"),
+    local = knitr::knit_global()
+  )
+}
 ```
 
 ```{css}


### PR DESCRIPTION
Presumably closes #135. Shouldn't need to source from the provided path when rendering on Connect, but knits locally just fine.