### PR TITLE
Add bed day definition into relevant note boxes

### DIFF
--- a/R/mod_model_core_activity.R
+++ b/R/mod_model_core_activity.R
@@ -16,6 +16,7 @@ mod_model_core_activity_ui <- function(id) {
       collapsible = FALSE,
       width = 12,
       htmltools::p(
+        "Bed days are defined as the difference in days between discharge and admission, plus one day.",
         "A&E results are not available at site level.",
         "See the",
         htmltools::a(

--- a/R/mod_model_results_distribution.R
+++ b/R/mod_model_results_distribution.R
@@ -17,6 +17,7 @@ mod_model_results_distribution_ui <- function(id) {
       collapsible = FALSE,
       width = 12,
       htmltools::p(
+        "Bed days are defined as the difference in days between discharge and admission, plus one day.",
         "A&E results are not available at site level.",
         "See the",
         htmltools::a(

--- a/R/mod_principal_change_factor_effects.R
+++ b/R/mod_principal_change_factor_effects.R
@@ -16,7 +16,8 @@ mod_principal_change_factor_effects_ui <- function(id) {
       collapsible = FALSE,
       width = 12,
       htmltools::p(
-        "The results should be regarded as rough, high-level estimates of the number of rows added/removed due to each parameter.",
+        "These results should be regarded as rough, high-level estimates of the number of rows added/removed due to each parameter.",
+        "Bed days are defined as the difference in days between discharge and admission, plus one day.",
         "See the",
         htmltools::a(
           href = "https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/glossary.html",

--- a/R/mod_principal_detailed.R
+++ b/R/mod_principal_detailed.R
@@ -16,6 +16,7 @@ mod_principal_detailed_ui <- function(id) {
       collapsible = FALSE,
       width = 12,
       htmltools::p(
+        "Bed days are defined as the difference in days between discharge and admission, plus one day.",
         "A&E results are not available at site level.",
         "See the",
         htmltools::a(

--- a/R/mod_principal_summary.R
+++ b/R/mod_principal_summary.R
@@ -16,6 +16,7 @@ mod_principal_summary_ui <- function(id) {
       collapsible = FALSE,
       width = 12,
       htmltools::p(
+        "Bed days are defined as the difference in days between discharge and admission, plus one day.",
         "A&E and bed-availability data are not available at site level.",
         "See the",
         htmltools::a(

--- a/R/mod_principal_summary_los.R
+++ b/R/mod_principal_summary_los.R
@@ -16,6 +16,7 @@ mod_principal_summary_los_ui <- function(id) {
       collapsible = FALSE,
       width = 12,
       htmltools::p(
+        "Bed days are defined as the difference in days between discharge and admission, plus one day.",
         "See the",
         htmltools::a(
           href = "https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/glossary.html",

--- a/tests/testthat/_snaps/app_ui.md
+++ b/tests/testthat/_snaps/app_ui.md
@@ -132,6 +132,7 @@
                       </div>
                       <div class="card-body">
                         <p>
+                          Bed days are defined as the difference in days between discharge and admission, plus one day.
                           See the
                           <a href="https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/glossary.html">model project information site</a>
                           for definitions of terms.

--- a/tests/testthat/_snaps/mod_model_core_activity.md
+++ b/tests/testthat/_snaps/mod_model_core_activity.md
@@ -11,6 +11,7 @@
           </div>
           <div class="card-body">
             <p>
+              Bed days are defined as the difference in days between discharge and admission, plus one day.
               A&amp;E results are not available at site level.
               See the
               <a href="https://connect.strategyunitwm.nhs.uk/nhp/project_information">model project information site</a>

--- a/tests/testthat/_snaps/mod_model_results_distribution.md
+++ b/tests/testthat/_snaps/mod_model_results_distribution.md
@@ -11,6 +11,7 @@
           </div>
           <div class="card-body">
             <p>
+              Bed days are defined as the difference in days between discharge and admission, plus one day.
               A&amp;E results are not available at site level.
               See the
               <a href="https://connect.strategyunitwm.nhs.uk/nhp/project_information">model project information site</a>

--- a/tests/testthat/_snaps/mod_principal_change_factor_effects.md
+++ b/tests/testthat/_snaps/mod_principal_change_factor_effects.md
@@ -11,7 +11,8 @@
           </div>
           <div class="card-body">
             <p>
-              The results should be regarded as rough, high-level estimates of the number of rows added/removed due to each parameter.
+              These results should be regarded as rough, high-level estimates of the number of rows added/removed due to each parameter.
+              Bed days are defined as the difference in days between discharge and admission, plus one day.
               See the
               <a href="https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/glossary.html">model project information site</a>
               for definitions of terms.

--- a/tests/testthat/_snaps/mod_principal_detailed.md
+++ b/tests/testthat/_snaps/mod_principal_detailed.md
@@ -11,6 +11,7 @@
           </div>
           <div class="card-body">
             <p>
+              Bed days are defined as the difference in days between discharge and admission, plus one day.
               A&amp;E results are not available at site level.
               See the
               <a href="https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/glossary.html">model project information site</a>

--- a/tests/testthat/_snaps/mod_principal_summary.md
+++ b/tests/testthat/_snaps/mod_principal_summary.md
@@ -11,6 +11,7 @@
           </div>
           <div class="card-body">
             <p>
+              Bed days are defined as the difference in days between discharge and admission, plus one day.
               A&amp;E and bed-availability data are not available at site level.
               See the
               <a href="https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/glossary.html">model project information site</a>

--- a/tests/testthat/_snaps/mod_principal_summary_los.md
+++ b/tests/testthat/_snaps/mod_principal_summary_los.md
@@ -11,6 +11,7 @@
           </div>
           <div class="card-body">
             <p>
+              Bed days are defined as the difference in days between discharge and admission, plus one day.
               See the
               <a href="https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/glossary.html">model project information site</a>
               for definitions of terms.


### PR DESCRIPTION
Adds bed days definition to note box on each tab that contains bed days data. See #143 (doesn't close because we aren't yet adding supporting advice). This prompted #145 as well.