### PR TITLE
fixes aggregations

### DIFF
--- a/R/fct_get_data.R
+++ b/R/fct_get_data.R
@@ -261,7 +261,7 @@ trust_site_aggregation <- function(data, sites) {
         c(
           tidyselect::where(is.character),
           tidyselect::where(is.factor),
-          dplyr::matches("model_run|year"),
+          tidyselect::any_of(c("model_run", "year")),
           -"sitetret"
         )
       )


### PR DESCRIPTION
previously we selected the 'model_run' column, but the regex also matched 'model_runs'.
in v1.2.0 we started to keep the full model_runs for all aggregatsions, so the grouping
broke.

this change specifically targets the 'model_run' column (aswell as the year column),
which only exist when the 'model_runs' or 'time_profiles' columns are unnested.
