### PR TITLE
Add 'extract' label directly to downloadable reports

### DIFF
--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -1,5 +1,5 @@
 ---
-title: NHP Outputs Report 
+title: "NHP Outputs Report (Extract B)"
 output:
   html_document:
     toc: true

--- a/inst/report-parameters.Rmd
+++ b/inst/report-parameters.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "NHP Parameters Report"
+title: "NHP Parameters Report (Extract A)"
 subtitle: "Scenario: `r params$r$params$scenario`"
 output:
   html_document:


### PR DESCRIPTION
Closes #201.

Handling an oversight in #207, which added labels in the app but not the reports.