### PR TITLE
Remove NA option from 'show results by' dropdown

### DIFF
--- a/R/mod_principal_detailed.R
+++ b/R/mod_principal_detailed.R
@@ -113,7 +113,10 @@ mod_principal_detailed_server <- function(id, selected_data, selected_site) {
 
       an <- c("age_group" = "Age Group", "tretspef" = "Treatment Specialty")
 
-      shiny::updateSelectInput(session, "aggregation", choices = unname(an[a]))
+      agg_choices <- unname(an[a])
+      agg_choices <- agg_choices[!is.na(agg_choices)]
+
+      shiny::updateSelectInput(session, "aggregation", choices = agg_choices)
     })
 
     aggregated_data <- shiny::reactive({


### PR DESCRIPTION
Closes #213.

Filters out possible `NA` option when updating the `choice` argument in `updateSelectInput()` for the 'Show results by' dropdown in the 'Activity in detail' tab.