### PR TITLE
Add metadata to cover sheet of Excel download

### DIFF
--- a/R/mod_info_downloads.R
+++ b/R/mod_info_downloads.R
@@ -99,9 +99,9 @@ mod_info_downloads_download_excel <- function(data) {
       decimal.mark = "/"
     )
 
-    # params_list[["create_datetime"]] <- params_list[["create_datetime"]] |>
-    #   lubridate::fast_strptime("%Y%m%d_%H%M%S") |>
-    #   format("%d-%b-%Y %H:%M:%S")
+    params_list[["create_datetime"]] <- params_list[["create_datetime"]] |>
+      lubridate::fast_strptime("%Y%m%d_%H%M%S") |>
+      format("%d-%b-%Y %H:%M:%S")
 
     params_df <- params_list |> unlist() |> tibble::enframe()
 

--- a/tests/testthat/test-mod_info_downloads.R
+++ b/tests/testthat/test-mod_info_downloads.R
@@ -29,7 +29,7 @@ test_that("ui is created correctly", {
 test_that("it generates an excel file", {
   data <- \() {
     list(
-      params = list(x = 1, y = 2),
+      params = list(x = 1, y = "x", create_datetime = "20220101_000000"),
       results = list(
         a = tibble::tibble(
           x = 1:3,
@@ -54,7 +54,10 @@ test_that("it generates an excel file", {
     m,
     1,
     list(
-      metadata = tibble::tibble(name = c("x", "y"), value = c("1", "2")),
+      metadata = tibble::tibble(
+        name = c("x", "y", "create_datetime"),
+        value = c("1", "x", "01-Jan-2022 00:00:00")
+      ),
       a = tibble::tibble(x = 1:3, y = 4:6)
     ),
     "file"


### PR DESCRIPTION
Close #217.

Small techdebt: may want to 'functionise' the financial-year logic/making datetime human readable (I think this is used in a couple of places now).