### PR TITLE
Revert "adds ability to redistribute the model interaction term"

### DIFF
--- a/R/fct_get_data.R
+++ b/R/fct_get_data.R
@@ -109,64 +109,10 @@ patch_principal <- function(results, name) {
 }
 
 patch_principal_step_counts <- function(results) {
-  step_counts <- dplyr::mutate(
+  dplyr::mutate(
     results,
     value = purrr::map_dbl(.data[["model_runs"]], mean)
   )
-
-  no_interaction_term_rows <- step_counts |>
-    dplyr::filter(.data[["change_factor"]] %in% c("baseline", "efficiencies")) |>
-    dplyr::mutate(value_redistributed = .data[["value"]])
-
-  interaction_term_rows <- dplyr::anti_join(
-    step_counts,
-    dplyr::distinct(no_interaction_term_rows, .data[["change_factor"]]),
-    "change_factor"
-  )
-
-  activity_resampling <- dplyr::filter(interaction_term_rows, .data[["change_factor"]] != "activity_avoidance")
-
-  ar_i_term <- activity_resampling |>
-    dplyr::filter(.data[["change_factor"]] == "model_interaction_term") |>
-    dplyr::select(-"change_factor", -"strategy", -"model_runs") |>
-    dplyr::rename("value_redistributed" = "value")
-
-  activity_resampling <- activity_resampling |>
-    dplyr::inner_join(ar_i_term, by = c("pod", "sitetret", "activity_type", "measure")) |>
-    dplyr::mutate(
-      .by = c("pod", "sitetret", "activity_type", "measure"),
-      value_tmp = ifelse(
-        .data[["change_factor"]] == "model_interaction_term",
-        NA_real_,
-        .data[["value"]]
-      ),
-      dplyr::across("value_tmp", \(.x) .x / sum(.x, na.rm = TRUE)),
-      value_redistributed = .data[["value"]] + .data[["value_redistributed"]] * .data[["value_tmp"]],
-    ) |>
-    dplyr::select(-"value_tmp")
-
-  activity_avoidance <- dplyr::filter(interaction_term_rows, .data[["change_factor"]] == "activity_avoidance")
-
-  aa_i_term <- activity_avoidance |>
-    dplyr::filter(.data[["strategy"]] == "activity_avoidance_interaction_term") |>
-    dplyr::select(-"change_factor", -"strategy", -"model_runs") |>
-    dplyr::rename("value_redistributed" = "value")
-
-  activity_avoidance <- activity_avoidance |>
-    dplyr::inner_join(aa_i_term, by = c("pod", "sitetret", "activity_type", "measure")) |>
-    dplyr::mutate(
-      .by = c("pod", "sitetret", "activity_type", "measure"),
-      value_tmp = ifelse(
-        .data[["strategy"]] == "activity_avoidance_interaction_term",
-        NA_real_,
-        .data[["value"]]
-      ),
-      dplyr::across("value_tmp", \(.x) .x / sum(.x, na.rm = TRUE)),
-      value_redistributed = .data[["value"]] + .data[["value_redistributed"]] * .data[["value_tmp"]],
-    ) |>
-    dplyr::select(-"value_tmp")
-
-  dplyr::bind_rows(no_interaction_term_rows, activity_resampling, activity_avoidance)
 }
 
 patch_step_counts <- function(results) {

--- a/tests/testthat/_snaps/mod_principal_change_factor_effects.md
+++ b/tests/testthat/_snaps/mod_principal_change_factor_effects.md
@@ -75,14 +75,6 @@
                 </label>
               </div>
             </div>
-            <div class="form-group shiny-input-container">
-              <div class="checkbox">
-                <label>
-                  <input id="id-redistribute_model_interaction_term" type="checkbox" class="shiny-input-checkbox" checked="checked"/>
-                  <span>Redistribute Model Interaction Term?</span>
-                </label>
-              </div>
-            </div>
             <div data-spinner-id="spinner-fac52137bd9b9ca575e47193636bb3fb" class="shiny-spinner-output-container shiny-spinner-hideui">
               <div class="load-container shiny-spinner-hidden load1">
                 <div id="spinner-fac52137bd9b9ca575e47193636bb3fb" class="loader">Loading...</div>

--- a/tests/testthat/test-fct_get_data.R
+++ b/tests/testthat/test-fct_get_data.R
@@ -269,39 +269,13 @@ test_that("patch_principal returns correct values (step_counts)", {
 })
 
 test_that("patch_principal_step_counts returns correct values", {
-  # TODO: fix this test
   # arrange
-  results <- tibble::tribble(
-    ~change_factor, ~strategy, ~model_runs,
-    "baseline", "-", c(1),
-    "a", "-", c(2, 3, 4),
-    "b", "-", c(4, 5, 6),
-    "model_interaction_term", "-", c(7, 8, 9),
-    "activity_avoidance", "a", c(1, 2, 3),
-    "activity_avoidance", "b", c(4, 5, 6),
-    "activity_avoidance", "activity_avoidance_interaction_term", c(2, 3, 4),
-    "efficiencies", "a", c(1, 2, 3),
-    "efficiencies", "b", c(4, 5, 6)
-  ) |>
-    dplyr::mutate(
-      sitetret = "a",
-      pod = "a",
-      activity_type = "a",
-      measure = "a"
-    )
-
-  expected <- tibble::tribble(
-    ~change_factor, ~strategy, ~model_runs, ~sitetret, ~pod, ~activity_type, ~measure, ~value, ~value_redistributed,
-    "baseline", "-", 1, "a", "a", "a", "a", 1, 1,
-    "efficiencies", "a", c(1, 2, 3), "a", "a", "a", "a", 2, 2,
-    "efficiencies", "b", c(4, 5, 6), "a", "a", "a", "a", 5, 5,
-    "a", "-", c(2, 3, 4), "a", "a", "a", "a", 3, 6,
-    "b", "-", c(4, 5, 6), "a", "a", "a", "a", 5, 10,
-    "model_interaction_term", "-", c(7, 8, 9), "a", "a", "a", "a", 8, NA,
-    "activity_avoidance", "a", c(1, 2, 3), "a", "a", "a", "a", 2, 2.85714285714286,
-    "activity_avoidance", "b", c(4, 5, 6), "a", "a", "a", "a", 5, 7.14285714285714,
-    "activity_avoidance", "activity_avoidance_interaction_term", c(2, 3, 4), "a", "a", "a", "a", 3, NA
+  results <- tibble::tibble(
+    change_factor = c("baseline", "x"),
+    model_runs = list(1, 2:4)
   )
+  expected <- results |>
+    dplyr::mutate(value = c(1, 3))
 
   # act
   actual <- patch_principal_step_counts(results)

--- a/tests/testthat/test-mod_principal_change_factor_effects.R
+++ b/tests/testthat/test-mod_principal_change_factor_effects.R
@@ -15,31 +15,30 @@ atpmo_expected <- tibble::tribble(
   "op", "Outpatients", "op_first", "First Outpatient Attendance", "tele_attendances"
 )
 
-# Begin Exclude Linting
 change_factors_expected <- list(
   aae = tibble::tribble(
-    ~pod, ~sitetret, ~measure, ~change_factor, ~strategy, ~mitigator_name, ~value, ~value_redistributed,
-    "aae_type-01", "R00", "arrivals", "baseline", "-", "-", 10000, 100000,
-    "aae_type-01", "R00", "arrivals", "frequent_attenders", "-", "-", -400, -4000,
-    "aae_type-01", "R00", "arrivals", "health_status_adjustment", "-", "-", -100, -1000,
-    "aae_type-01", "R00", "arrivals", "left_before_seen", "-", "-", -50, -500,
-    "aae_type-01", "R00", "arrivals", "low_cost_discharged", "-", "-", -600, -6000,
-    "aae_type-01", "R00", "arrivals", "demographic_adjustment", "-", "-", 1400, 14000
+    ~pod, ~sitetret, ~measure, ~change_factor, ~strategy, ~mitigator_name, ~value,
+    "aae_type-01", "R00", "arrivals", "baseline", "-", "-", 100000,
+    "aae_type-01", "R00", "arrivals", "frequent_attenders", "-", "-", -4000,
+    "aae_type-01", "R00", "arrivals", "health_status_adjustment", "-", "-", -1000,
+    "aae_type-01", "R00", "arrivals", "left_before_seen", "-", "-", -500,
+    "aae_type-01", "R00", "arrivals", "low_cost_discharged", "-", "-", -6000,
+    "aae_type-01", "R00", "arrivals", "demographic_adjustment", "-", "-", 14000
   ),
   ip = tibble::tribble(
-    ~pod, ~sitetret, ~measure, ~change_factor, ~strategy, ~mitigator_name, ~value, ~value_redistributed,
-    "ip_elective_admission", "R00", "admissions", "baseline", "-", "-", 10000, 100000,
-    "ip_elective_admission", "R00", "admissions", "demographic_adjustment", "-", "-", 1500, 15000,
-    "ip_elective_admission", "R00", "admissions", "health_status_adjustment", "-", "-", -100, -1000,
-    "ip_elective_admission", "R00", "admissions", "activity_avoidance", "alcohol_wholly_attributable", "Alcohol Related Admissions (Wholly Attributable) (IP-AA-003)", -10, -100,
-    "ip_elective_admission", "R00", "admissions", "activity_avoidance", "ambulatory_care_conditions_acute", "Ambulatory Care Sensitive Admissions (Acute Conditions) (IP-AA-004)", -250, -25,
-    "ip_elective_admission", "R00", "admissions", "activity_avoidance", "ambulatory_care_conditions_chronic", "Ambulatory Care Sensitive Admissions (Chronic Conditions) (IP-AA-005)", -30, -300,
-    "ip_elective_admission", "R00", "beddays", "baseline", "-", "-", 20000, 200000,
-    "ip_elective_admission", "R00", "beddays", "demographic_adjustment", "-", "-", 3000, 30000,
-    "ip_elective_admission", "R00", "beddays", "health_status_adjustment", "-", "-", -200, -2000,
-    "ip_elective_admission", "R00", "beddays", "activity_avoidance", "alcohol_wholly_attributable", "Alcohol Related Admissions (Wholly Attributable) (IP-AA-003)", -20, -200,
-    "ip_elective_admission", "R00", "beddays", "activity_avoidance", "ambulatory_care_conditions_acute", "Ambulatory Care Sensitive Admissions (Acute Conditions) (IP-AA-004)", -50, -500,
-    "ip_elective_admission", "R00", "beddays", "activity_avoidance", "ambulatory_care_conditions_chronic", "Ambulatory Care Sensitive Admissions (Chronic Conditions) (IP-AA-005)", -60, -600
+    ~pod, ~sitetret, ~measure, ~change_factor, ~strategy, ~mitigator_name, ~value,
+    "ip_elective_admission", "R00", "admissions", "baseline", "-", "-", 100000,
+    "ip_elective_admission", "R00", "admissions", "demographic_adjustment", "-", "-", 15000,
+    "ip_elective_admission", "R00", "admissions", "health_status_adjustment", "-", "-", -1000,
+    "ip_elective_admission", "R00", "admissions", "activity_avoidance", "alcohol_wholly_attributable", "Alcohol Related Admissions (Wholly Attributable) (IP-AA-003)", -100,
+    "ip_elective_admission", "R00", "admissions", "activity_avoidance", "ambulatory_care_conditions_acute", "Ambulatory Care Sensitive Admissions (Acute Conditions) (IP-AA-004)", -250,
+    "ip_elective_admission", "R00", "admissions", "activity_avoidance", "ambulatory_care_conditions_chronic", "Ambulatory Care Sensitive Admissions (Chronic Conditions) (IP-AA-005)", -300,
+    "ip_elective_admission", "R00", "beddays", "baseline", "-", "-", 200000,
+    "ip_elective_admission", "R00", "beddays", "demographic_adjustment", "-", "-", 30000,
+    "ip_elective_admission", "R00", "beddays", "health_status_adjustment", "-", "-", -2000,
+    "ip_elective_admission", "R00", "beddays", "activity_avoidance", "alcohol_wholly_attributable", "Alcohol Related Admissions (Wholly Attributable) (IP-AA-003)", -200,
+    "ip_elective_admission", "R00", "beddays", "activity_avoidance", "ambulatory_care_conditions_acute", "Ambulatory Care Sensitive Admissions (Acute Conditions) (IP-AA-004)", -500,
+    "ip_elective_admission", "R00", "beddays", "activity_avoidance", "ambulatory_care_conditions_chronic", "Ambulatory Care Sensitive Admissions (Chronic Conditions) (IP-AA-005)", -600
   )
 ) |>
   purrr::map(~ dplyr::mutate(
@@ -50,19 +49,18 @@ change_factors_expected <- list(
       \(.x) forcats::fct_relevel(.x, "baseline", "demographic_adjustment", "health_status_adjustment")
     )
   ))
-# End Exclude Linting
 
 change_factors_summarised_expected_inc_baseline <- tibble::tribble(
   ~change_factor, ~colour, ~name, ~value,
-  "baseline", "#f9bf07", "value", 10000,
+  "baseline", "#f9bf07", "value", 100000,
   "baseline", NA, "hidden", 0,
-  "demographic_adjustment", "#f9bf07", "value", 1500,
-  "demographic_adjustment", NA, "hidden", 10000,
-  "activity_avoidance", "#2c2825", "value", 290,
-  "activity_avoidance", NA, "hidden", 11210,
-  "health_status_adjustment", "#2c2825", "value", 100,
-  "health_status_adjustment", NA, "hidden", 11110,
-  "Estimate", "#ec6555", "value", 11110,
+  "demographic_adjustment", "#f9bf07", "value", 15000,
+  "demographic_adjustment", NA, "hidden", 100000,
+  "activity_avoidance", "#2c2825", "value", 650,
+  "activity_avoidance", NA, "hidden", 114350,
+  "health_status_adjustment", "#2c2825", "value", 1000,
+  "health_status_adjustment", NA, "hidden", 113350,
+  "Estimate", "#ec6555", "value", 113350,
   "Estimate", NA, "hidden", 0
 ) |>
   dplyr::mutate(
@@ -84,13 +82,13 @@ change_factors_summarised_expected_inc_baseline <- tibble::tribble(
 
 change_factors_summarised_expected_exc_baseline <- tibble::tribble(
   ~change_factor, ~colour, ~name, ~value,
-  "demographic_adjustment", "#f9bf07", "value", 1500,
+  "demographic_adjustment", "#f9bf07", "value", 15000,
   "demographic_adjustment", NA, "hidden", 0,
-  "activity_avoidance", "#2c2825", "value", 290,
-  "activity_avoidance", NA, "hidden", 1210,
-  "health_status_adjustment", "#2c2825", "value", 100,
-  "health_status_adjustment", NA, "hidden", 1110,
-  "Estimate", "#ec6555", "value", 1110,
+  "activity_avoidance", "#2c2825", "value", 650,
+  "activity_avoidance", NA, "hidden", 14350,
+  "health_status_adjustment", "#2c2825", "value", 1000,
+  "health_status_adjustment", NA, "hidden", 13350,
+  "Estimate", "#ec6555", "value", 13350,
   "Estimate", NA, "hidden", 0
 ) |>
   dplyr::mutate(
@@ -172,36 +170,6 @@ test_that("it sets up the activity_type dropdown", {
   })
 })
 
-test_that("it changes what column is used", {
-  stub(mod_principal_change_factor_effects_server, "get_activity_type_pod_measure_options", atpmo_expected)
-  stub(
-    mod_principal_change_factor_effects_server,
-    "get_principal_change_factors",
-    dplyr::select(change_factors_expected$aae, -"mitigator_name")
-  )
-
-  selected_data <- reactiveVal()
-  selected_sites <- reactiveVal("R00")
-
-  testServer(mod_principal_change_factor_effects_server, args = list(selected_data, selected_sites), {
-    expected <- change_factors_expected$aae |>
-      dplyr::mutate(value = .data[["value_redistributed"]]) |>
-      dplyr::select(-"value_redistributed")
-
-    session$setInputs(
-      "activity_type" = "aae",
-      "redistribute_model_interaction_term" = TRUE
-    )
-
-    expect_equal(sum(principal_change_factors_raw()[["value"]]), 102500)
-
-    session$setInputs(
-      "redistribute_model_interaction_term" = FALSE
-    )
-    expect_equal(sum(principal_change_factors_raw()[["value"]]), 10250)
-  })
-})
-
 test_that("it loads the data from when the activity_type or id changes", {
   m <- mock(
     dplyr::select(change_factors_expected$aae, -"mitigator_name"),
@@ -218,15 +186,9 @@ test_that("it loads the data from when the activity_type or id changes", {
     selected_data(1)
     expect_called(m, 0)
 
-    expected <- change_factors_expected$aae |>
-      dplyr::mutate(value = .data[["value_redistributed"]]) |>
-      dplyr::select(-"value_redistributed")
+    expected <- change_factors_expected$aae
 
-    session$setInputs(
-      "activity_type" = "aae",
-      "redistribute_model_interaction_term" = TRUE
-    )
-
+    session$setInputs("activity_type" = "aae")
     expect_equal(principal_change_factors_raw()[colnames(expected)], expected)
 
     selected_data(2)
@@ -255,10 +217,7 @@ test_that("it updates the measures dropdown when the change factors updates", {
   testServer(mod_principal_change_factor_effects_server, args = list(selected_data, selected_sites), {
     selected_data(1)
 
-    session$setInputs(
-      "activity_type" = "aae",
-      "redistribute_model_interaction_term" = TRUE
-    )
+    session$setInputs("activity_type" = "aae")
     principal_change_factors_raw()
 
     session$setInputs("activity_type" = "ip")
@@ -323,19 +282,14 @@ test_that("it sets up the individual change factors", {
   selected_sites <- reactiveVal("R00")
 
   testServer(mod_principal_change_factor_effects_server, args = list(selected_data, selected_sites), {
-    session$setInputs(
-      activity_type = "ip",
-      pods = "ip_elective_admission",
-      measure = "admissions",
-      sort_type = "Descending value",
-      include_baseline = TRUE,
-      redistribute_model_interaction_term = TRUE
-    )
     selected_data(1)
+    session$setInputs(activity_type = "ip")
+    session$setInputs(pods = "ip_elective_admission")
+    session$setInputs(measure = "admissions")
+    session$setInputs(sort_type = "Descending value")
+    session$setInputs(include_baseline = TRUE)
 
     expected <- change_factors_expected$ip |>
-      dplyr::mutate(value = .data[["value_redistributed"]]) |>
-      dplyr::select(-"value_redistributed") |>
       dplyr::filter(measure == "admissions", strategy != "-", value < 0)
 
     expected_1 <- expected |>
@@ -380,20 +334,17 @@ test_that("it renders the plots", {
   selected_sites <- reactiveVal("R00")
 
   testServer(mod_principal_change_factor_effects_server, args = list(selected_data, selected_sites), {
-    session$setInputs(
-      activity_type = "ip",
-      pods = "ip_elective_admission",
-      measure = "admissions",
-      sort_type = "Descending value",
-      include_baseline = TRUE,
-      redistribute_model_interaction_term = TRUE
-    )
+    session$setInputs(activity_type = "ip")
+    session$setInputs(pods = "ip_elective_admission")
+    session$setInputs(measure = "admissions")
+    session$setInputs(sort_type = "descending value")
+    session$setInputs(include_baseline = TRUE)
     selected_data(1)
 
-    expect_called(m, 3)
-    expect_args(m, 1, "cfd")
+    expect_called(m, 7)
+    expect_args(m, 3, "cfd")
 
-    expect_equal(mock_args(m)[[2]][-1], list("activity_avoidance", "#f9bf07", "Activity Avoidance", "Admissions"))
-    expect_equal(mock_args(m)[[3]][-1], list("efficiencies", "#ec6555", "Efficiencies", "Admissions"))
+    expect_equal(mock_args(m)[[6]][-1], list("activity_avoidance", "#f9bf07", "Activity Avoidance", "Admissions"))
+    expect_equal(mock_args(m)[[7]][-1], list("efficiencies", "#ec6555", "Efficiencies", "Admissions"))
   })
 })


### PR DESCRIPTION
Reverts The-Strategy-Unit/nhp_outputs#266

Turn's out there are edge cases that cause the old behaviour of everything "flipping", usually for smaller pod's