### PR TITLE
Interpret and display data from updated NDG json structure

### DIFF
--- a/R/mod_info_params.R
+++ b/R/mod_info_params.R
@@ -88,6 +88,20 @@ mod_info_params_ui <- function(id) {
       title = "Non-demographic adjustment",
       collapsed = TRUE,
       width = 12,
+      shiny::tags$p(
+        "Variant:",
+        shiny::textOutput(
+          ns("variant_non_demographic_adjustment"),
+          inline = TRUE
+        )
+      ),
+      shiny::tags$p(
+        "Value type:",
+        shiny::textOutput(
+          ns("value_type_non_demographic_adjustment"),
+          inline = TRUE
+        )
+      ),
       gt::gt_output(ns("params_non_demographic_adjustment"))
     ),
     bs4Dash::box(
@@ -113,6 +127,8 @@ mod_info_params_server <- function(id, selected_data) {
     params_data <- shiny::reactive({
       get_params(selected_data())
     })
+
+    # params
 
     output$params_demographic_factors <- gt::render_gt({
       info_params_table_demographic_adjustment(params_data())
@@ -154,6 +170,8 @@ mod_info_params_server <- function(id, selected_data) {
       info_params_table_efficiencies(params_data())
     })
 
+    # time profiles
+
     output$time_profile_waiting_list_adjustment <- shiny::renderText({
       params_data()[["time_profile_mappings"]][["waiting_list_adjustment"]]
     })
@@ -168,6 +186,16 @@ mod_info_params_server <- function(id, selected_data) {
 
     output$time_profile_repat_nonlocal <- shiny::renderText({
       params_data()[["time_profile_mappings"]][["repat_nonlocal"]]
+    })
+
+    # NDG
+
+    output$variant_non_demographic_adjustment <- shiny::renderText({
+      params_data()[["non-demographic_adjustment"]][["variant"]]
+    })
+
+    output$value_type_non_demographic_adjustment <- shiny::renderText({
+      params_data()[["non-demographic_adjustment"]][["value-type"]]
     })
   })
 }

--- a/R/mod_info_params_fct_tables.R
+++ b/R/mod_info_params_fct_tables.R
@@ -162,7 +162,7 @@ info_params_table_expat_repat_adjustment <- function(p, type) {
 }
 
 info_params_table_non_demographic_adjustment <- function(p) {
-  non_demographic_adjustment <- p[["non-demographic_adjustment"]]
+  non_demographic_adjustment <- p[["non-demographic_adjustment"]][["values"]]
 
   shiny::validate(
     shiny::need(non_demographic_adjustment, "No parameters provided")

--- a/inst/sample_params.json
+++ b/inst/sample_params.json
@@ -824,43 +824,47 @@
     }
   },
   "non-demographic_adjustment": {
-    "ip": {
-      "elective": [
-        1,
-        1.02
-      ],
-      "non-elective": [
-        1,
-        1.02
-      ],
-      "maternity": [
-        1,
-        1.02
-      ]
-    },
-    "op": {
-      "first": [
-        1,
-        1.02
-      ],
-      "followup": [
-        1,
-        1.02
-      ],
-      "procedure": [
-        1,
-        1.02
-      ]
-    },
-    "aae": {
-      "ambulance": [
-        1,
-        1.02
-      ],
-      "walk-in": [
-        1,
-        1.02
-      ]
+    "variant": "ndg-test",
+    "value-type": "year-on-year-growth",
+    "values": {
+      "ip": {
+        "elective": [
+          1,
+          1.02
+        ],
+        "non-elective": [
+          1,
+          1.02
+        ],
+        "maternity": [
+          1,
+          1.02
+        ]
+      },
+      "op": {
+        "first": [
+          1,
+          1.02
+        ],
+        "followup": [
+          1,
+          1.02
+        ],
+        "procedure": [
+          1,
+          1.02
+        ]
+      },
+      "aae": {
+        "ambulance": [
+          1,
+          1.02
+        ],
+        "walk-in": [
+          1,
+          1.02
+        ]
+      }
     }
   },
   "activity_avoidance": {

--- a/tests/testthat/_snaps/mod_info_params.md
+++ b/tests/testthat/_snaps/mod_info_params.md
@@ -159,6 +159,14 @@
             </div>
           </div>
           <div class="card-body">
+            <p>
+              Variant:
+              <span id="id-variant_non_demographic_adjustment" class="shiny-text-output"></span>
+            </p>
+            <p>
+              Value type:
+              <span id="id-value_type_non_demographic_adjustment" class="shiny-text-output"></span>
+            </p>
             <div id="id-params_non_demographic_adjustment" class="shiny-html-output"></div>
           </div>
         </div>


### PR DESCRIPTION
Close #292.

* Interprets the new, more nested structure of NDG (see https://github.com/The-Strategy-Unit/nhp_planning/issues/203).
* Displays the `variant` and `value-type` above the table of `values` in the 'input parameters' section of the app.
* Updated `sample_params.json`.
* Resnapshot.

Result (using a test file; normally the variant would be like 'variant_2'):

![image](https://github.com/user-attachments/assets/14ee3ec7-07f0-46af-a85f-15dcf626f064)
