### PR TITLE
Make beeswarm pop-projection-variant legend more readable

### DIFF
--- a/R/mod_model_results_distribution.R
+++ b/R/mod_model_results_distribution.R
@@ -60,19 +60,24 @@ mod_model_results_distribution_beeswarm_plot <- function(data, show_origin) {
   b <- data$baseline[[1]]
   p <- data$principal[[1]]
 
+  variant_lookup <- get_golem_config("population_projections")[["values"]] |>
+    unlist() |>
+    tibble::enframe(name = "variant", value = "Population-projection variant")
+
   x_placeholder <- "100%" # dummy label to help line up beeswarm and ECDF plots
 
   data |>
     require_rows() |>
+    dplyr::left_join(variant_lookup, "variant") |>
     ggplot2::ggplot() +
     suppressWarnings(
       ggbeeswarm::geom_quasirandom(
         ggplot2::aes(
           x = x_placeholder,
           y = .data$value,
-          colour = .data$variant,
+          colour = .data$`Population-projection variant`,
           text = glue::glue(
-            "Value: {scales::comma(value, accuracy = 1)}\nVariant: {variant}"
+            "Value: {scales::comma(value, accuracy = 1)}\nVariant: {`Population-projection variant`}"
           )
         ),
         alpha = 0.5

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -92,6 +92,15 @@ default:
     ambulance: Ambulance Arrivals
     arrivals: Arrivals
 
+  population_projections:
+    values:
+      migration_category: "Migration category"
+      var_proj_5_year_migration: "5 year migration trends"
+      var_proj_10_year_migration: "10 year migration trends"
+      var_proj_high_intl_migration: "High migration"
+      var_proj_low_intl_migration: "Low migration"
+      var_proj_zero_net_migration: "Zero net migration"
+
 production:
   app_prod: yes
 dev:


### PR DESCRIPTION
Close #330.

* Chose _not_ to remove the legend, but make it more readable (and more flexible if multi-variant selection is made available in the inputs app at some point in the future).
* Added population-projection variants to golem-config (as per inputs config).
* Used variant lookup table to give friendly names to user-facing variant variables ('High migration' rather than 'var_proj_high_intl_migration').

<img width="1161" height="553" alt="image" src="https://github.com/user-attachments/assets/20e97cef-87fa-4b2d-be36-5d0b45044303" />
