### PR TITLE
Add tribble format commit to blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,4 @@
 # Changes related to use of Air formatter
 06115438be48c241b143ec93199cdc4d0f5eb57a
 acba4f6163847879f27f0e0fa2fd517c3a72327d
+2aeab718870baf525ee8720dc1d019c209253164


### PR DESCRIPTION
Contributes to #335, should have been added in #336.

* Add SHA for commit that rewidens tribbles after elongation by Air.