### PR TITLE
R package check on PRs to all branches (not just main)

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,5 @@
 on:
   pull_request:
-    branches: [main]
 
 name: Check package
 


### PR DESCRIPTION
⚠️ Merge #383 first

I think package check should happen on _any_ PR. Not just on PR to `main`.

For example, with our work on {reskit}, I'll be making many small PRs in to a feature branch `use-reskit`.
It is helpful to run pkg check on those PRs (even though we are not making a PR into `main`)