### PR TITLE
:link: Use nhp_outputs GitHub URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Authors@R: c(
   )
 Description: A shiny app for showing outputs of the NHP model.
 License: MIT + file LICENSE
-URL: https://github.com/The-Strategy-Unit/nhp_model
-BugReports: https://github.com/The-Strategy-Unit/nhp_model/issues
+URL: https://github.com/The-Strategy-Unit/nhp_outputs
+BugReports: https://github.com/The-Strategy-Unit/nhp_outputs/issues
 Depends:
     R (>= 4.1.0)
 Imports: 


### PR DESCRIPTION
We used to point to `nhp_model` (I think when we had everything in a mono-repo? 🚝 )

Given that we actively monitor this repo and issues, it makes sense to point folk to `nhp_outputs` instead of `nhp_model`