### PR TITLE
📸 More robust snapshots

### DIFF
--- a/tests/testthat/_snaps/app_ui.md
+++ b/tests/testthat/_snaps/app_ui.md
@@ -13,9 +13,7 @@
                 </a>
               </li>
             </ul>
-            <button id="feedback" type="button" class="btn btn-default action-button" onClick="window.open(&#39;https://example.com/&#39;, &#39;_blank&#39;)">
-              <span class="action-label">Give feedback</span>
-            </button>
+            <button id="feedback" type="button" class="btn btn-default action-button" onClick="window.open(&#39;https://example.com/&#39;, &#39;_blank&#39;)"><span class="action-label">Give feedback</span></button>
             <ul class="navbar-nav ml-auto navbar-right">
               <li class="nav-item">
                 <a id="controlbar-toggle" class="nav-link" data-widget="control-sidebar" href="#">

--- a/tests/testthat/_snaps/mod_model_results_distribution.md
+++ b/tests/testthat/_snaps/mod_model_results_distribution.md
@@ -70,9 +70,9 @@
           </div>
           <div class="card-body">
             <div id="id-beeswarm_text" class="shiny-html-output"></div>
-            <div data-spinner-id="spinner-5096125134745c938fcb784237b4fc5f" class="shiny-spinner-output-container shiny-spinner-hideui">
+            <div data-spinner-id="spinner-<id>" class="shiny-spinner-output-container shiny-spinner-hideui">
               <div class="load-container shiny-spinner-hidden load1">
-                <div id="spinner-5096125134745c938fcb784237b4fc5f" class="loader">Loading...</div>
+                <div id="spinner-<id>" class="loader">Loading...</div>
               </div>
               <div class="plotly html-widget html-widget-output shiny-report-size shiny-report-theme html-fill-item" id="id-beeswarm" style="width:100%;height:400px;"></div>
             </div>
@@ -87,9 +87,9 @@
           </div>
           <div class="card-body">
             <div id="id-ecdf_text" class="shiny-html-output"></div>
-            <div data-spinner-id="spinner-38f304dc046a4e120f7add4378ad6a45" class="shiny-spinner-output-container shiny-spinner-hideui">
+            <div data-spinner-id="spinner-<id>" class="shiny-spinner-output-container shiny-spinner-hideui">
               <div class="load-container shiny-spinner-hidden load1">
-                <div id="spinner-38f304dc046a4e120f7add4378ad6a45" class="loader">Loading...</div>
+                <div id="spinner-<id>" class="loader">Loading...</div>
               </div>
               <div class="plotly html-widget html-widget-output shiny-report-size shiny-report-theme html-fill-item" id="id-ecdf" style="width:100%;height:400px;"></div>
             </div>

--- a/tests/testthat/_snaps/mod_principal_change_factor_effects.md
+++ b/tests/testthat/_snaps/mod_principal_change_factor_effects.md
@@ -75,9 +75,9 @@
                 </label>
               </div>
             </div>
-            <div data-spinner-id="spinner-4bb5a5bd9d3b9e19708a5d8f68f724ac" class="shiny-spinner-output-container shiny-spinner-hideui">
+            <div data-spinner-id="spinner-<id>" class="shiny-spinner-output-container shiny-spinner-hideui">
               <div class="load-container shiny-spinner-hidden load1">
-                <div id="spinner-4bb5a5bd9d3b9e19708a5d8f68f724ac" class="loader">Loading...</div>
+                <div id="spinner-<id>" class="loader">Loading...</div>
               </div>
               <div class="plotly html-widget html-widget-output shiny-report-size shiny-report-theme html-fill-item" id="id-change_factors" style="width:100%;height:600px;"></div>
             </div>
@@ -99,9 +99,9 @@
                 <script type="application/json" data-for="id-sort_type" data-nonempty="">{"plugins":["selectize-plugin-a11y"]}</script>
               </div>
             </div>
-            <div data-spinner-id="spinner-eba815bfed7ffb1d30927a66e18249e6" class="shiny-spinner-output-container shiny-spinner-hideui">
+            <div data-spinner-id="spinner-<id>" class="shiny-spinner-output-container shiny-spinner-hideui">
               <div class="load-container shiny-spinner-hidden load1">
-                <div id="spinner-eba815bfed7ffb1d30927a66e18249e6" class="loader">Loading...</div>
+                <div id="spinner-<id>" class="loader">Loading...</div>
               </div>
               <div class="row">
                 <div class="plotly html-widget html-widget-output shiny-report-size shiny-report-theme html-fill-item" id="id-activity_avoidance" style="width:100%;height:600px;"></div>

--- a/tests/testthat/test-app_ui.R
+++ b/tests/testthat/test-app_ui.R
@@ -41,7 +41,15 @@ test_that("ui is created correctly", {
     withr::with_envvar(
       c("FEEDBACK_FORM_URL" = "https://example.com/"),
       app_ui()
-    )
+    ),
+    transform = \(lines) {
+      # Normalise whitespace around <button> and <span>
+      gsub(
+        "\\s*<span class=\"action-label\">(.*?)</span>\\s*",
+        "<span class=\"action-label\">\\1</span>",
+        lines
+      )
+    }
   )
 
   expect_called(m, 8)

--- a/tests/testthat/test-mod_model_results_distribution.R
+++ b/tests/testthat/test-mod_model_results_distribution.R
@@ -23,7 +23,18 @@ model_run_distribution_expected <- tibble::tribble(
 
 test_that("ui is created correctly", {
   set.seed(123)
-  expect_snapshot(mod_model_results_distribution_ui("id"))
+  expect_snapshot(
+    mod_model_results_distribution_ui("id"),
+    transform = \(lines) {
+      # Mask both id and data-spinner-id attributes
+      lines <- gsub("id=\"spinner-[0-9a-f]+\"", "id=\"spinner-<id>\"", lines)
+      gsub(
+        "data-spinner-id=\"spinner-[0-9a-f]+\"",
+        "data-spinner-id=\"spinner-<id>\"",
+        lines
+      )
+    }
+  )
 })
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/tests/testthat/test-mod_principal_change_factor_effects.R
+++ b/tests/testthat/test-mod_principal_change_factor_effects.R
@@ -132,7 +132,18 @@ change_factors_summarised_expected_exc_baseline <- tibble::tribble(
 
 test_that("ui is created correctly", {
   set.seed(123)
-  expect_snapshot(mod_principal_change_factor_effects_ui("id"))
+  expect_snapshot(
+    mod_principal_change_factor_effects_ui("id"),
+    transform = \(lines) {
+      # Mask both id and data-spinner-id attributes
+      lines <- gsub("id=\"spinner-[0-9a-f]+\"", "id=\"spinner-<id>\"", lines)
+      gsub(
+        "data-spinner-id=\"spinner-[0-9a-f]+\"",
+        "data-spinner-id=\"spinner-<id>\"",
+        lines
+      )
+    }
+  )
 })
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
A couple of small things were causing artificial failing snapshots

- Random spinner-ids 🌀
- Whitespace of span around feedback button ⚪


This has meant that [developers needed to "resnapshot"](https://github.com/The-Strategy-Unit/nhp_outputs/commit/bf3a449f34abc5da924c56c6d519824bea0cb700)


Instead we should use the[ `transform` argument of `expect_snapshot()`](https://testthat.r-lib.org/articles/snapshotting.html#other-challenges) to explicitly mask these insignificant differences


## Random spinner-ids 🌀

The spinner-id issue and fix is simple enough. The `id` is being randomly generated, and I'm using regex to switch out 

 `<div data-spinner-id="spinner-5096125134745c938fcb784237b4fc5f">`
with 
`<div data-spinner-id="spinner-id">`

## Whitespace of span around feedback button ⚪

This is a bit of weird one. On some environments, the span for the feedback appears on a newline, on others it does not.
We've [seen this before.](https://github.com/The-Strategy-Unit/nhp_outputs/commit/bf3a449f34abc5da924c56c6d519824bea0cb700#diff-916dca2819b538473537377a1638be3ea9f71530fc7ec83526a480b5be2dca53R16)  I think the way actionButtons get rendered got changed somewhere along the way. 

<img width="931" height="185" alt="Screenshot 2026-03-02 164715" src="https://github.com/user-attachments/assets/5425609a-9428-446d-bb95-7cf72c061f16" />


To be safe I've just normalised the whitespace around that span. 
I used Claude to help me work out the regex and it might not quite be right so would appreciate you having a second look @tomjemmett 