### PR TITLE
:house: Use local lookups

### DIFF
--- a/R/ZZZ.R
+++ b/R/ZZZ.R
@@ -89,6 +89,18 @@ server_get_results <- function(session) {
   )
 }
 
+
+get_tretspef_lookup <- function(
+  tretspef_lookup = app_sys("app", "data", "tx-lookup.json")
+) {
+  tretspef_lookup |>
+    yyjsonr::read_json_file() |>
+    dplyr::select(
+      "code" = "Code",
+      "tretspef" = "Description"
+    )
+}
+
 get_tpma_lookup <- function(
   tpma_lookup = app_sys("app", "data", "mitigators.json")
 ) {

--- a/R/ZZZ.R
+++ b/R/ZZZ.R
@@ -89,16 +89,16 @@ server_get_results <- function(session) {
   )
 }
 
-get_mitigator_lookup <- function(
-  mitigator_lookup = app_sys("app", "data", "mitigators.json")
+get_tpma_lookup <- function(
+  tpma_lookup = app_sys("app", "data", "mitigators.json")
 ) {
-  mitigator_lookup |>
+  tpma_lookup |>
     yyjsonr::read_json_file() |>
     purrr::simplify() |>
-    tibble::enframe("strategy", "mitigator_name") |>
+    tibble::enframe("strategy", "tpma_label") |>
     dplyr::mutate(
-      mitigator_code = stringr::str_extract(
-        .data[["mitigator_name"]],
+      tpma_code = stringr::str_extract(
+        .data[["tpma_label"]],
         "[:upper:]{2}-[:upper:]{2}-[:digit:]{3}"
       )
     )

--- a/R/fct_report.R
+++ b/R/fct_report.R
@@ -65,7 +65,8 @@ generate_activity_in_detail_table <- function(
       activity_type = activity_type,
       aggregation = agg_col,
       pods = pod,
-      sites = sites
+      sites = sites,
+      tretspef_lookup = get_tretspef_lookup()
     )
 
   # if a site is selected then there are no rows for A&E

--- a/R/mod_info_downloads.R
+++ b/R/mod_info_downloads.R
@@ -108,8 +108,8 @@ mod_info_downloads_download_excel <- function(data) {
 
     # Add the mitigator reference numbers
     results_dfs[["step_counts"]] <- results_dfs[["step_counts"]] |>
-      dplyr::left_join(get_mitigator_lookup(), by = "strategy") |>
-      dplyr::relocate("mitigator_name", "mitigator_code", .after = "strategy")
+      dplyr::left_join(get_tpma_lookup(), by = "strategy") |>
+      dplyr::relocate("tpma_label", "tpma_code", .after = "strategy")
 
     params_list <- data() |>
       purrr::pluck("params") |>

--- a/R/mod_info_params_fct_tables.R
+++ b/R/mod_info_params_fct_tables.R
@@ -6,11 +6,10 @@ info_params_fix_data <- function(df) {
       )
     )
 
-  specs <- app_sys("app", "data", "tx-lookup.json") |>
-    yyjsonr::read_json_file() |>
+  specs <- get_tretspef_lookup() |>
     dplyr::select(
-      "specialty" = "Code",
-      "specialty_name" = "Description"
+      "specialty" = "code",
+      "specialty_name" = "tretspef"
     )
 
   strategies <- app_sys("app", "data", "mitigators.json") |>

--- a/R/mod_principal_change_factor_effects.R
+++ b/R/mod_principal_change_factor_effects.R
@@ -162,7 +162,8 @@ mod_principal_change_factor_effects_server <- function(
           activity_type = input$activity_type,
           pods = input$pods,
           sites = selected_site(),
-          include_baseline = input$include_baseline
+          include_baseline = input$include_baseline,
+          tpma_lookup = get_tpma_lookup()
         ) |>
         require_rows() |>
         reskit::make_overall_cf_plot() +
@@ -178,7 +179,8 @@ mod_principal_change_factor_effects_server <- function(
           activity_type = input$activity_type,
           pods = input$pods,
           sites = selected_site(),
-          sort_by = input$sort_type
+          sort_by = input$sort_type,
+          tpma_lookup = get_tpma_lookup()
         ) |>
         require_rows() |>
         reskit::make_individual_cf_plot() +

--- a/R/mod_principal_detailed.R
+++ b/R/mod_principal_detailed.R
@@ -81,7 +81,8 @@ mod_principal_detailed_server <- function(id, selected_data, selected_site) {
           activity_type = selected_measure()$activity_type,
           aggregation = input$aggregation,
           pods = selected_measure()$pods,
-          sites = selected_site()
+          sites = selected_site(),
+          tretspef_lookup = get_tretspef_lookup()
         ) |>
         require_rows() |>
         reskit::make_detailed_activity_table(final_year = end_year)

--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -142,6 +142,7 @@ params$r |>
     measure = "beddays",
     activity_type = "ip",
     sites = params$sites,
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_overall_cf_plot()
 
@@ -151,7 +152,8 @@ params$r |>
     measure = "beddays",
     activity_type = "ip",
     sites = params$sites,
-    sort_by = "value"
+    sort_by = "value",
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -167,6 +169,7 @@ params$r |>
     measure = "admissions",
     activity_type = "ip",
     sites = params$sites,
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_overall_cf_plot()
 
@@ -176,7 +179,8 @@ params$r |>
     measure = "admissions",
     activity_type = "ip",
     sites = params$sites,
-    sort_by = "value"
+    sort_by = "value",
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -194,9 +198,9 @@ params$r |>
     measure = "attendances",
     activity_type = "op",
     sites = params$sites,
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_overall_cf_plot()
-
 
 params$r |>
   reskit::shim_results() |>
@@ -204,7 +208,8 @@ params$r |>
     measure = "attendances",
     activity_type = "op",
     sites = params$sites,
-    sort_by = "value"
+    sort_by = "value",
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -220,9 +225,9 @@ params$r |>
     measure = "tele_attendances",
     activity_type = "op",
     sites = params$sites,
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_overall_cf_plot()
-
 
 params$r |>
   reskit::shim_results() |>
@@ -230,7 +235,8 @@ params$r |>
     measure = "tele_attendances",
     activity_type = "op",
     sites = params$sites,
-    sort_by = "value"
+    sort_by = "value",
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -248,9 +254,9 @@ params$r |>
     measure = "arrivals",
     activity_type = "aae",
     sites = params$sites,
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_overall_cf_plot()
-
 
 params$r |>
   reskit::shim_results() |>
@@ -258,7 +264,8 @@ params$r |>
     measure = "arrivals",
     activity_type = "aae",
     sites = params$sites,
-    sort_by = "value"
+    sort_by = "value",
+    tpma_lookup = get_tpma_lookup()
   ) |>
   reskit::make_individual_cf_plot()
 ```

--- a/tests/testthat/test-mod_info_downloads.R
+++ b/tests/testthat/test-mod_info_downloads.R
@@ -93,12 +93,12 @@ test_that("it generates an excel file", {
           "convert_to_tele_adult_non-surgical",
           "discharged_no_treatment_adult_ambulance"
         ),
-        mitigator_name = c(
+        tpma_label = c(
           "Alcohol Related Admissions (Acute Conditions - Partially Attributable) (IP-AA-001)",
           "Outpatient Convert to Tele-Attendance (Adult, Non-Surgical) (OP-EF-001)",
           "A&E Discharged No Investigation or Treatment (Adult, Ambulance Conveyed) (AE-AA-001)"
         ),
-        mitigator_code = c(
+        tpma_code = c(
           "IP-AA-001",
           "OP-EF-001",
           "AE-AA-001"


### PR DESCRIPTION
As discussed before closing #404 - the outputs app should pull lookups {nhp_outputs} rather than {reskit} to avoid any versioning issues. 

The lookups affected are:
- `mitigators.json`
- `tx-lookup.json`

The reskit arguments which have been overwritten are:

- `compile_change_factor_data(tpma_lookup = )`
- `compile_indiv_change_factor_data(tpma_lookup = )`
- `compile_detailed_activity_data(tretspef_lookup = )`

The default is to pull from {reskit}

Note that pods are still being pulled from both reskit & local to Outputs

Note that POD lookups still come from both reskit and Outputs #406 