### PR TITLE
Ensure A&E appears in outputs following reskit integration

### DIFF
--- a/R/mod_principal_change_factor_effects.R
+++ b/R/mod_principal_change_factor_effects.R
@@ -169,8 +169,8 @@ mod_principal_change_factor_effects_server <- function(
           pods = input$pods,
           sites = selected_site(),
           include_baseline = input$include_baseline,
-          tpma_lookup = reskit:::get_tpma_label_lookup(),
-          pod_lookup = reskit:::get_principal_pods()
+          tpma_lookup = reskit::get_tpma_label_lookup(),
+          pod_lookup = reskit::get_principal_pods()
         ) |>
         require_rows() |>
         reskit::make_overall_cf_plot() +
@@ -187,8 +187,8 @@ mod_principal_change_factor_effects_server <- function(
           pods = input$pods,
           sites = selected_site(),
           sort_by = input$sort_type,
-          tpma_lookup = reskit:::get_tpma_label_lookup(),
-          pod_lookup = reskit:::get_principal_pods()
+          tpma_lookup = reskit::get_tpma_label_lookup(),
+          pod_lookup = reskit::get_principal_pods()
         ) |>
         require_rows() |>
         reskit::make_individual_cf_plot() +

--- a/R/mod_principal_change_factor_effects.R
+++ b/R/mod_principal_change_factor_effects.R
@@ -169,8 +169,8 @@ mod_principal_change_factor_effects_server <- function(
           pods = input$pods,
           sites = selected_site(),
           include_baseline = input$include_baseline,
-          tpma_lookup = get_tpma_lookup(),
-          pod_lookup = get_pod_lookup()
+          tpma_lookup = reskit:::get_tpma_label_lookup(),
+          pod_lookup = reskit:::get_principal_pods()
         ) |>
         require_rows() |>
         reskit::make_overall_cf_plot() +
@@ -187,8 +187,8 @@ mod_principal_change_factor_effects_server <- function(
           pods = input$pods,
           sites = selected_site(),
           sort_by = input$sort_type,
-          tpma_lookup = get_tpma_lookup(),
-          pod_lookup = get_pod_lookup()
+          tpma_lookup = reskit:::get_tpma_label_lookup(),
+          pod_lookup = reskit:::get_principal_pods()
         ) |>
         require_rows() |>
         reskit::make_individual_cf_plot() +

--- a/R/mod_principal_summary.R
+++ b/R/mod_principal_summary.R
@@ -39,7 +39,7 @@ mod_principal_summary_server <- function(id, selected_data, selected_site) {
         reskit::shim_results() |>
         reskit::compile_principal_pod_data(
           sites = selected_site(),
-          pod_lookup = reskit:::get_principal_pods()
+          pod_lookup = reskit::get_principal_pods()
         )
     })
 

--- a/R/mod_principal_summary.R
+++ b/R/mod_principal_summary.R
@@ -39,7 +39,7 @@ mod_principal_summary_server <- function(id, selected_data, selected_site) {
         reskit::shim_results() |>
         reskit::compile_principal_pod_data(
           sites = selected_site(),
-          pod_lookup = get_pod_lookup()
+          pod_lookup = reskit:::get_principal_pods()
         )
     })
 

--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -77,7 +77,7 @@ params$r |>
   reskit::shim_results() |>
   reskit::compile_principal_pod_data(
     sites = params$sites,
-    pod_lookup = get_pod_lookup()
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_principal_pod_table() |>
   gt::tab_options(table.align = "left")
@@ -93,7 +93,8 @@ params$r |>
 params$r |>
   reskit::shim_results() |>
   reskit::compile_principal_los_data(
-    measure = "beddays", sites = params$sites,
+    measure = "beddays",
+    sites = params$sites,
     pod_lookup = get_pod_lookup()
   ) |>
   reskit::make_principal_los_table() |>

--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -122,7 +122,7 @@ The results should be regarded as rough, high-level estimates of the number of r
 
 ```{r}
 #| label: pp-impact-of-changes-setup
-#|
+
 possibly_compile_change_factor_data <-
   purrr::possibly(
     reskit::compile_change_factor_data,
@@ -149,8 +149,8 @@ params$r |>
     measure = "beddays",
     activity_type = "ip",
     sites = params$sites,
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
 
@@ -161,8 +161,8 @@ params$r |>
     activity_type = "ip",
     sites = params$sites,
     sort_by = "value",
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -178,8 +178,8 @@ params$r |>
     measure = "admissions",
     activity_type = "ip",
     sites = params$sites,
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
 
@@ -190,8 +190,8 @@ params$r |>
     activity_type = "ip",
     sites = params$sites,
     sort_by = "value",
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -209,8 +209,8 @@ params$r |>
     measure = "attendances",
     activity_type = "op",
     sites = params$sites,
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
 
@@ -221,8 +221,8 @@ params$r |>
     activity_type = "op",
     sites = params$sites,
     sort_by = "value",
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -238,8 +238,8 @@ params$r |>
     measure = "tele_attendances",
     activity_type = "op",
     sites = params$sites,
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
 
@@ -250,8 +250,8 @@ params$r |>
     activity_type = "op",
     sites = params$sites,
     sort_by = "value",
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_individual_cf_plot()
 ```
@@ -269,8 +269,8 @@ params$r |>
     measure = "arrivals",
     activity_type = "aae",
     sites = params$sites,
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
 
@@ -281,8 +281,8 @@ params$r |>
     activity_type = "aae",
     sites = params$sites,
     sort_by = "value",
-    tpma_lookup = get_tpma_lookup(),
-    pod_lookup = get_pod_lookup()
+    tpma_lookup = reskit::get_tpma_label_lookup(),
+    pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_individual_cf_plot()
 ```


### PR DESCRIPTION
Close #429.

* Used {reskit} `get_principal_pods()` and `get_tpma_label_lookup()` for (a) the principal summary table and (b) the change-factor charts.
* Did the same for the reports.