### PR TITLE
Read (and handle) parquet results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ rsconnect/
 # ignore config files
 config*.py
 
-__PYCACHE__
-__pycache__
-
 # ignore any potential data/artifacts
 *.zip
 *.parquet
@@ -68,6 +65,12 @@ coverage.xml
 # worktrees
 results_selection_app/
 
+# sample results
 inst/sample_results.json
+inst/sample_results/params.json
+inst/sample_results/variants.json
 
+# caching
+__PYCACHE__
+__pycache__
 .cache

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ BugReports: https://github.com/The-Strategy-Unit/nhp_outputs/issues
 Depends:
     R (>= 4.5.0)
 Imports:
+    arrow,
     azkit (>= 0.3.1),
-    AzureStor,
     bs4Dash,
     cachem,
     config (>= 0.3.1),
@@ -49,6 +49,7 @@ Imports:
     yyjsonr,
     zeallot
 Suggests:
+    AzureStor,
     covr,
     devtools,
     languageserver,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     markdown,
     plotly,
     purrr,
-    reskit (>= 1.0.0),
+    reskit (>= 1.0.1),
     rlang,
     rmarkdown,
     scales,

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -34,8 +34,8 @@ app_server <- function(input, output, session) {
   selected_data <- shiny::reactive({
     tryCatch(
       {
-        file <- model_metadata()$results_json_gz_path
-        get_results_from_azure(file)
+        results_dir <- model_metadata()$aggregated_results_path
+        get_results_from_azure(results_dir)
       },
       error = \(e) {
         session$allowReconnect(FALSE)

--- a/R/fct_get_data.R
+++ b/R/fct_get_data.R
@@ -36,154 +36,43 @@ get_model_run_from_ats <- function(dataset, model_run_id) {
   )
 }
 
-get_results_from_azure <- function(filename) {
-  cont <- azkit::get_container(
+get_results_from_azure <- function(directory) {
+  container <- azkit::get_container(
     container_name = Sys.getenv("AZ_STORAGE_CONTAINER"),
     endpoint_url = Sys.getenv("AZ_STORAGE_EP")
   )
 
-  AzureStor::download_blob(cont, filename, NULL) |>
-    memDecompress(type = "gzip") |>
-    yyjsonr::read_json_raw(
-      yyjsonr::opts_read_json(
-        obj_of_arrs_to_df = FALSE
-      )
-    ) |>
-    parse_results()
+  blobs <- AzureStor::list_blobs(container, directory) |> dplyr::pull(name)
+  params_file <- blobs[grepl("params\\.json$", blobs)]
+  variants_file <- blobs[grepl("variants\\.json$", blobs)]
+  parquet_files <- blobs[grepl("\\.parquet$", blobs)]
+  results_names <- parquet_files |> basename() |> tools::file_path_sans_ext()
+
+  params <- azkit::read_azure_json(container, params_file)
+  population_variants <- azkit::read_azure_json(container, variants_file)
+  results <- purrr::map(
+    parquet_files,
+    \(file) azkit::read_azure_parquet(container, file)
+  ) |>
+    purrr::set_names(results_names)
+
+  dplyr::lst(params, population_variants, results)
 }
 
-get_results_from_local <- function(filename) {
-  filename |>
-    yyjsonr::read_json_file(
-      yyjsonr::opts_read_json(
-        obj_of_arrs_to_df = FALSE
-      )
-    ) |>
-    parse_results()
-}
+get_results_from_local <- function(directory) {
+  files <- list.files(directory, full.names = TRUE)
+  params_file <- files[grepl("params\\.json$", files)]
+  variants_file <- files[grepl("variants\\.json$", files)]
+  parquet_files <- files[grepl("\\.parquet$", files)]
+  results_names <- parquet_files |> basename() |> tools::file_path_sans_ext()
 
-parse_results <- function(r) {
-  r$population_variants <- as.character(r$population_variants)
+  params <- yyjsonr::read_json_file(params_file)
+  population_variants <- yyjsonr::read_json_file(variants_file)
+  results <- parquet_files |>
+    purrr::map(arrow::read_parquet) |>
+    purrr::set_names(results_names)
 
-  r$results <- purrr::map(
-    r$results,
-    tibble::as_tibble
-  )
-
-  r$params <- patch_params(r$params)
-
-  patch_results(r)
-}
-
-patch_params <- function(r) {
-  if (is.list(r)) {
-    return(purrr::map(r, patch_params))
-  }
-
-  if (is.numeric(r) && length(r) == 2) {
-    return(as.list(r))
-  }
-
-  r
-}
-
-patch_principal <- function(results, name) {
-  if (name == "step_counts") {
-    return(patch_principal_step_counts(results))
-  }
-
-  dplyr::mutate(
-    results,
-    principal = purrr::map_dbl(.data[["model_runs"]], mean),
-    median = purrr::map_dbl(.data[["model_runs"]], stats::quantile, 0.5),
-    lwr_pi = purrr::map_dbl(.data[["model_runs"]], stats::quantile, 0.1),
-    upr_pi = purrr::map_dbl(.data[["model_runs"]], stats::quantile, 0.9)
-  )
-}
-
-patch_principal_step_counts <- function(results) {
-  dplyr::mutate(
-    results,
-    value = purrr::map_dbl(.data[["model_runs"]], mean)
-  )
-}
-
-patch_step_counts <- function(results) {
-  if (!"strategy" %in% colnames(results$step_counts)) {
-    results$step_counts <- dplyr::mutate(
-      results$step_counts,
-      strategy = NA_character_,
-      .after = "change_factor"
-    )
-  }
-  results
-}
-
-patch_results <- function(r) {
-  r$results <- purrr::imap(r$results, patch_principal)
-  r$results <- patch_step_counts(r$results)
-
-  r$results[["tretspef+los_group"]] <- r$results[[
-    "tretspef+los_group"
-  ]] |>
-    dplyr::mutate(
-      dplyr::across(
-        "los_group",
-        \(.x) {
-          forcats::lvls_expand(
-            # order and include potentially missing levels
-            .x,
-            c(
-              "0 days",
-              "1 day",
-              "2 days",
-              "3 days",
-              "4-7 days",
-              "8-14 days",
-              "15-21 days",
-              "22+ days"
-            )
-          )
-        }
-      )
-    ) |>
-    dplyr::arrange(.data$pod, .data$measure, .data$sitetret, .data$los_group)
-
-  r$results[["sex+age_group"]] <- r$results[["sex+age_group"]] |>
-    dplyr::mutate(
-      dplyr::across(
-        "age_group",
-        \(.x) {
-          forcats::lvls_expand(
-            # order and include potentially missing levels
-            .x,
-            c(
-              "0",
-              "1-4",
-              "5-9",
-              "10-15",
-              "16-17",
-              "18-34",
-              "35-49",
-              "50-64",
-              "65-74",
-              "75-84",
-              "85+",
-              "Unknown"
-            )
-          )
-        }
-      )
-    ) |>
-    dplyr::arrange(
-      .data$pod,
-      .data$measure,
-      .data$sitetret,
-      .data$sex,
-      .data$age_group
-    )
-
-  r
+  dplyr::lst(params, population_variants, results)
 }
 
 get_user_allowed_datasets <- function(groups) {

--- a/R/fct_get_data.R
+++ b/R/fct_get_data.R
@@ -42,28 +42,20 @@ get_results_from_azure <- function(directory) {
     endpoint_url = Sys.getenv("AZ_STORAGE_EP")
   )
 
-  blobs <- AzureStor::list_blobs(container, directory) |> dplyr::pull(name)
-  params_file <- blobs[grepl("params\\.json$", blobs)]
-  variants_file <- blobs[grepl("variants\\.json$", blobs)]
-  parquet_files <- blobs[grepl("\\.parquet$", blobs)]
-  results_names <- parquet_files |> basename() |> tools::file_path_sans_ext()
+  params_file <- file.path(directory, "params.json")
+  variants_file <- file.path(directory, "variants.json")
 
   params <- azkit::read_azure_json(container, params_file) |> patch_params()
   population_variants <- azkit::read_azure_json(container, variants_file)
-  results <- purrr::map(
-    parquet_files,
-    \(file) azkit::read_azure_parquet(container, file)
-  ) |>
-    purrr::set_names(results_names)
+  results <- reskit::read_results_parquet_files(container, directory)
 
   dplyr::lst(params, population_variants, results)
 }
 
-get_results_from_local <- function(directory) {
-  files <- list.files(directory, full.names = TRUE)
-  params_file <- files[grepl("params\\.json$", files)]
-  variants_file <- files[grepl("variants\\.json$", files)]
-  parquet_files <- files[grepl("\\.parquet$", files)]
+get_results_from_local <- function(directory = "inst/sample_results") {
+  params_file <- file.path(directory, "params.json")
+  variants_file <- file.path(directory, "variants.json")
+  parquet_files <- list.files(directory, "\\.parquet$", full.names = TRUE)
   results_names <- parquet_files |> basename() |> tools::file_path_sans_ext()
 
   params <- yyjsonr::read_json_file(params_file) |> patch_params()

--- a/R/fct_get_data.R
+++ b/R/fct_get_data.R
@@ -48,7 +48,7 @@ get_results_from_azure <- function(directory) {
   parquet_files <- blobs[grepl("\\.parquet$", blobs)]
   results_names <- parquet_files |> basename() |> tools::file_path_sans_ext()
 
-  params <- azkit::read_azure_json(container, params_file)
+  params <- azkit::read_azure_json(container, params_file) |> patch_params()
   population_variants <- azkit::read_azure_json(container, variants_file)
   results <- purrr::map(
     parquet_files,
@@ -66,7 +66,7 @@ get_results_from_local <- function(directory) {
   parquet_files <- files[grepl("\\.parquet$", files)]
   results_names <- parquet_files |> basename() |> tools::file_path_sans_ext()
 
-  params <- yyjsonr::read_json_file(params_file)
+  params <- yyjsonr::read_json_file(params_file) |> patch_params()
   population_variants <- yyjsonr::read_json_file(variants_file)
   results <- parquet_files |>
     purrr::map(arrow::read_parquet) |>
@@ -88,6 +88,18 @@ get_user_allowed_datasets <- function(groups) {
   }
 
   c("synthetic", p)
+}
+
+patch_params <- function(r) {
+  if (is.list(r)) {
+    return(purrr::map(r, patch_params))
+  }
+
+  if (is.numeric(r) && length(r) == 2) {
+    return(as.list(r))
+  }
+
+  r
 }
 
 get_trust_sites <- function(r) {

--- a/R/fct_report.R
+++ b/R/fct_report.R
@@ -58,16 +58,15 @@ generate_activity_in_detail_table <- function(
   measure,
   agg_col
 ) {
-  aggregated_data <- data |>
-    reskit::shim_results() |>
+  aggregated_data <- data$results |>
     reskit::compile_detailed_activity_data(
       measure = measure,
       activity_type = activity_type,
       aggregation = agg_col,
       pods = pod,
       sites = sites,
-      tretspef_lookup = get_tretspef_lookup(),
-      pod_lookup = get_pod_lookup()
+      tretspef_lookup = reskit::get_tretspef_lookup(),
+      pod_lookup = reskit::get_detailed_pods()
     )
 
   # if a site is selected then there are no rows for A&E
@@ -100,14 +99,13 @@ plot_activity_distributions <- function(
   pod,
   measure
 ) {
-  aggregated_data <- data |>
-    reskit::shim_results() |>
+  aggregated_data <- data$results |>
     reskit::compile_distribution_plot_data(
       measure = measure,
       activity_type = activity_type,
       pods = pod,
       sites = sites,
-      pod_lookup = get_pod_lookup()
+      pod_lookup = reskit::get_detailed_pods()
     ) |>
     require_rows()
 
@@ -195,23 +193,19 @@ param_tables_to_list <- function(p) {
 #'     object `p` to [param_tables_to_list]. Each element is a parameter group
 #'     ('baseline adjustment', etc) and contains a 'gt' table object
 #'     describing the parameter selections, or a further list with elements for
-#'     a 'gt' object and a character value (the time profile mapping).
+#'     a 'gt' object and a character value.
 #' @noRd
 expand_param_tables_to_rmd <- function(param_tables_list) {
   l1_names <- names(param_tables_list) # 'l1' as in 'level 1' of the list
 
   for (l1 in l1_names) {
     cat("##", l1, "\n\n")
-
     l1_object <- param_tables_list[[l1]]
     l1_is_gt <- inherits(l1_object, "gt_tbl")
     l1_is_list <- is.list(l1_object)
 
     if (l1_is_gt) {
-      l1_object |>
-        gt::tab_options(table.align = "left") |>
-        htmltools::tagList() |>
-        print()
+      render_params_gt(l1_object)
     }
 
     if (!l1_is_gt && l1_is_list) {
@@ -221,20 +215,34 @@ expand_param_tables_to_rmd <- function(param_tables_list) {
         l2_object <- l1_object[[l2]]
         l2_is_char <- is.character(l2_object)
         l2_is_gt <- inherits(l2_object, "gt_tbl")
+        l2_is_empty <- is.null(l2_object)
+
+        if (l2_is_empty) {
+          cat("No parameters were selected.\n\n")
+        }
 
         if (l2_is_char) {
           cat(paste0(l2, ":"), l2_object, "\n\n")
         }
 
         if (l2_is_gt) {
-          l2_object |>
-            gt::tab_options(table.align = "left") |>
-            htmltools::tagList() |>
-            print()
+          render_params_gt(l2_object)
         }
       }
     }
   }
+}
+
+#' Render a 'gt' Table of Parameter Selections as Raw HTML
+#' @param param_table A data.frame. Contains parameter selections made in the
+#'     inputs app. The data.frame is an element of `param_tables_list` provided
+#'     to [expand_param_tables_to_rmd].
+#' @noRd
+render_params_gt <- function(param_table) {
+  param_table |>
+    gt::tab_options(table.align = "left") |>
+    gt::as_raw_html() |>
+    cat()
 }
 
 #' Expand a List of Parameter-Selection Reasons to R Markdown

--- a/R/mod_info_downloads_helpers.R
+++ b/R/mod_info_downloads_helpers.R
@@ -1,3 +1,48 @@
+mod_info_downloads_reformat_all_results <- function(r) {
+  r$results <- purrr::imap(
+    r$results,
+    \(dat, dat_name) {
+      if (dat_name == "step_counts") {
+        mod_info_downloads_reformat_step_counts(dat)
+      } else {
+        mod_info_downloads_reformat_results(dat)
+      }
+    }
+  )
+  r
+}
+
+mod_info_downloads_reformat_step_counts <- function(dat) {
+  dat |>
+    dplyr::summarise(
+      .by = -c(.data$model_run, .data$value),
+      model_runs = list(.data$value),
+      value = purrr::map_dbl(.data$model_runs, mean)
+    )
+}
+
+mod_info_downloads_reformat_results <- function(dat) {
+  baseline <- dat |>
+    dplyr::filter(.data$model_run == 0) |>
+    dplyr::select(-.data$model_run) |>
+    dplyr::rename(baseline = .data$value)
+
+  summaries <- dat |>
+    dplyr::filter(.data$model_run != 0) |>
+    dplyr::summarise(
+      .by = -c(.data$model_run, .data$value),
+      principal = mean(.data$value),
+      model_runs = list(.data$value),
+      median = stats::quantile(.data$value, 0.5),
+      lwr_pi = stats::quantile(.data$value, 0.1),
+      upr_pi = stats::quantile(.data$value, 0.9)
+    )
+
+  # Join by all common cols
+  join_cols <- intersect(names(baseline), names(summaries))
+  dplyr::left_join(baseline, summaries, by = join_cols)
+}
+
 mod_info_downloads_download_excel <- function(data) {
   function(file) {
     results_dfs <- data() |>

--- a/R/mod_info_downloads_server.R
+++ b/R/mod_info_downloads_server.R
@@ -7,36 +7,43 @@ mod_info_downloads_server <- function(id, selected_data, selected_site) {
     shiny::observe({
       shiny::req(selected_data())
 
+      # Activate buttons only when data is available
       shinyjs::enable("download_results_xlsx")
       shinyjs::enable("download_results_json")
-
       shinyjs::enable("download_report_parameters_html")
       shinyjs::enable("download_report_outputs_html")
     }) |>
       shiny::bindEvent(selected_data())
 
-    # download buttons ----
+    # prepare data ----
+
+    # reshape parquet input to the form expected by download functions
+    reshaped_data <- shiny::reactive({
+      shiny::req(selected_data())
+      mod_info_downloads_reformat_all_results(selected_data())
+    })
 
     filename_stub <- shiny::reactive({
-      p <- selected_data()$params
+      p <- reshaped_data()$params
       create_datetime <- stringr::str_replace(p$create_datetime, "_", "-")
       paste(p$dataset, p$scenario, create_datetime, sep = "-") |> tolower()
     })
+
+    # download buttons ----
 
     # results
 
     output$download_results_xlsx <- shiny::downloadHandler(
       filename = \() paste0(filename_stub(), "_results.xlsx"),
-      content = mod_info_downloads_download_excel(selected_data)
+      content = mod_info_downloads_download_excel(reshaped_data)
     )
 
     output$download_results_json <- shiny::downloadHandler(
       filename = \() paste0(filename_stub(), "_results.json"),
-      ,
-      content = mod_info_downloads_download_json(selected_data)
+      content = mod_info_downloads_download_json(reshaped_data)
     )
 
-    # params
+    # params report (extract A)
 
     output$download_report_parameters_html <- shiny::downloadHandler(
       filename = \() {
@@ -44,11 +51,12 @@ mod_info_downloads_server <- function(id, selected_data, selected_site) {
       },
       content = mod_info_downloads_download_report_html(
         selected_data,
+        selected_site,
         report_type = "parameters"
       )
     )
 
-    # outputs (plots, tables, etc)
+    # outputs summary report (extract B)
 
     output$download_report_outputs_html <- shiny::downloadHandler(
       filename = \() paste0(filename_stub(), "_report-outputs_extract-b.html"),

--- a/R/mod_model_core_activity_server.R
+++ b/R/mod_model_core_activity_server.R
@@ -4,8 +4,7 @@
 mod_model_core_activity_server <- function(id, selected_data, selected_site) {
   shiny::moduleServer(id, function(input, output, session) {
     output$core_activity_median <- gt::render_gt({
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_distribution_summary_data(
           value_type = "median",
           sites = selected_site(),
@@ -15,8 +14,7 @@ mod_model_core_activity_server <- function(id, selected_data, selected_site) {
     })
 
     output$core_activity_principal <- gt::render_gt({
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_distribution_summary_data(
           value_type = "principal",
           sites = selected_site(),

--- a/R/mod_model_results_distribution_server.R
+++ b/R/mod_model_results_distribution_server.R
@@ -10,8 +10,7 @@ mod_model_results_distribution_server <- function(
     selected_measure <- mod_measure_selection_server("measure_selection")
 
     aggregated_data <- shiny::reactive({
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_distribution_plot_data(
           measure = selected_measure()$measure,
           activity_type = selected_measure()$activity_type,

--- a/R/mod_principal_change_factor_effects_server.R
+++ b/R/mod_principal_change_factor_effects_server.R
@@ -89,8 +89,7 @@ mod_principal_change_factor_effects_server <- function(
 
     output$change_factors <- shiny::renderPlot({
       shiny::req(input$pods)
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_change_factor_data(
           measure = input$measure,
           activity_type = input$activity_type,
@@ -107,8 +106,7 @@ mod_principal_change_factor_effects_server <- function(
 
     output$individual_change_factors <- shiny::renderPlot({
       shiny::req(input$pods)
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_indiv_change_factor_data(
           measure = input$measure,
           activity_type = input$activity_type,

--- a/R/mod_principal_detailed_server.R
+++ b/R/mod_principal_detailed_server.R
@@ -34,8 +34,7 @@ mod_principal_detailed_server <- function(id, selected_data, selected_site) {
 
       end_year <- selected_data()[["params"]][["end_year"]]
 
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_detailed_activity_data(
           measure = selected_measure()$measure,
           activity_type = selected_measure()$activity_type,

--- a/R/mod_principal_summary_los_server.R
+++ b/R/mod_principal_summary_los_server.R
@@ -4,8 +4,7 @@
 mod_principal_summary_los_server <- function(id, selected_data, selected_site) {
   shiny::moduleServer(id, function(input, output, session) {
     output$summary_los_table_beddays <- gt::render_gt({
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_principal_los_data(
           measure = "beddays",
           sites = selected_site(),
@@ -16,8 +15,7 @@ mod_principal_summary_los_server <- function(id, selected_data, selected_site) {
     })
 
     output$summary_los_table_admissions <- gt::render_gt({
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_principal_los_data(
           measure = "admissions",
           sites = selected_site(),

--- a/R/mod_principal_summary_server.R
+++ b/R/mod_principal_summary_server.R
@@ -4,8 +4,7 @@
 mod_principal_summary_server <- function(id, selected_data, selected_site) {
   shiny::moduleServer(id, function(input, output, session) {
     summary_data <- shiny::reactive({
-      selected_data() |>
-        reskit::shim_results() |>
+      selected_data()[["results"]] |>
         reskit::compile_principal_pod_data(
           sites = selected_site(),
           pod_lookup = reskit::get_principal_pods()

--- a/dev/run_dev.R
+++ b/dev/run_dev.R
@@ -9,7 +9,7 @@ mockery::stub(
   run_app,
   "server_get_results",
   depth = 2,
-  \(...) get_results_from_local("inst/sample_results.json")
+  \(...) get_results_from_local("inst/sample_results")
 )
 
 # need to explicitly print for VS Code debugger to work

--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -73,8 +73,7 @@ Bed-availability data is not available at site level. See [the model project inf
 ```{r}
 #| label: pp-summary
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   reskit::compile_principal_pod_data(
     sites = params$sites,
     pod_lookup = reskit::get_principal_pods()
@@ -90,8 +89,7 @@ params$r |>
 ```{r}
 #| label: pp-summary-los-beddays
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   reskit::compile_principal_los_data(
     measure = "beddays",
     sites = params$sites,
@@ -106,8 +104,7 @@ params$r |>
 ```{r}
 #| label: pp-summary-los-admissions
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   reskit::compile_principal_los_data(
     measure = "admissions",
     sites = params$sites,
@@ -144,8 +141,7 @@ possibly_compile_indiv_change_factor_data <-
 ```{r}
 #| label: pp-impact-of-changes-ip-bed-days
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_change_factor_data(
     measure = "beddays",
     activity_type = "ip",
@@ -155,8 +151,7 @@ params$r |>
   ) |>
   reskit::make_overall_cf_plot()
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_indiv_change_factor_data(
     measure = "beddays",
     activity_type = "ip",
@@ -173,8 +168,7 @@ params$r |>
 ```{r}
 #| label: pp-impact-of-changes-ip-admissions
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_change_factor_data(
     measure = "admissions",
     activity_type = "ip",
@@ -184,8 +178,7 @@ params$r |>
   ) |>
   reskit::make_overall_cf_plot()
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_indiv_change_factor_data(
     measure = "admissions",
     activity_type = "ip",
@@ -204,8 +197,7 @@ params$r |>
 ```{r}
 #| label: pp-impact-of-changes-op-attendances
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_change_factor_data(
     measure = "attendances",
     activity_type = "op",
@@ -215,8 +207,7 @@ params$r |>
   ) |>
   reskit::make_overall_cf_plot()
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_indiv_change_factor_data(
     measure = "attendances",
     activity_type = "op",
@@ -233,8 +224,7 @@ params$r |>
 ```{r}
 #| label: pp-impact-of-changes-op-tele-attendances
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_change_factor_data(
     measure = "tele_attendances",
     activity_type = "op",
@@ -244,8 +234,7 @@ params$r |>
   ) |>
   reskit::make_overall_cf_plot()
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_indiv_change_factor_data(
     measure = "tele_attendances",
     activity_type = "op",
@@ -264,8 +253,7 @@ params$r |>
 ```{r}
 #| label: pp-impact-of-changes-aae-arrivals
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_change_factor_data(
     measure = "arrivals",
     activity_type = "aae",
@@ -275,8 +263,7 @@ params$r |>
   ) |>
   reskit::make_overall_cf_plot()
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   possibly_compile_indiv_change_factor_data(
     measure = "arrivals",
     activity_type = "aae",
@@ -709,8 +696,7 @@ See [the model project information site](https://connect.strategyunitwm.nhs.uk/n
 ```{r}
 #| label: dop-activity-summary
 
-params$r |>
-  reskit::shim_results() |>
+params$r$results |>
   reskit::compile_distribution_summary_data(
     value_type = "median",
     sites = params$sites,

--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -16,8 +16,16 @@ params:
 #| label: setup
 #| echo: false
 
-knitr::opts_chunk$set(error = TRUE, echo = FALSE)
+knitr::opts_chunk$set(error = TRUE, echo = FALSE, out.width = "100%")
 pkgload::load_all(params$wd, quiet = TRUE)
+```
+
+```{r}
+#| label: chunk_vars
+#| echo: false
+
+icf_fig_height <- 7
+icf_font_size <- 10
 ```
 
 ```{r}
@@ -50,6 +58,9 @@ subtitle: "Scenario: `r params$r$params$scenario` (`r site_status`)"
 This report provides the outputs (tables and charts) from the selected model scenario (`r params$r$params$scenario`) for the following sites combined: `r selected_sites`.
 
 Note that some tables and charts won't be generated if there was insufficient data to produce them, given the combination of trust and site selections (if any).
+
+This document is produced dynamically and so plots may not be produced at optimal size. 
+Please [contact The Strategy Unit Data Science team](mailto:mlcsu.su.datascience@nhs.net) if this is a problem.
 
 See [the project information site](https://connect.strategyunitwm.nhs.uk/nhp/project_information) for an overview of the model and its methodology.
 
@@ -139,7 +150,7 @@ possibly_compile_indiv_change_factor_data <-
 #### Bed days
 
 ```{r}
-#| label: pp-impact-of-changes-ip-bed-days
+#| label: pp-impact-of-changes-overall-ip-bed-days
 
 params$r$results |>
   possibly_compile_change_factor_data(
@@ -150,6 +161,10 @@ params$r$results |>
     pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
+```
+
+```{r, fig.height=icf_fig_height}
+#| label: pp-impact-of-changes-individual-ip-bed-days
 
 params$r$results |>
   possibly_compile_indiv_change_factor_data(
@@ -160,13 +175,14 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot()
+  reskit::make_individual_cf_plot() +
+  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
 ```
 
 #### Admissions
 
 ```{r}
-#| label: pp-impact-of-changes-ip-admissions
+#| label: pp-impact-of-changes-overall-ip-admissions
 
 params$r$results |>
   possibly_compile_change_factor_data(
@@ -177,6 +193,10 @@ params$r$results |>
     pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
+```
+
+```{r, fig.height=icf_fig_height}
+#| label: pp-impact-of-changes-individual-ip-admissions
 
 params$r$results |>
   possibly_compile_indiv_change_factor_data(
@@ -187,7 +207,8 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot()
+  reskit::make_individual_cf_plot() +
+  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
 ```
 
 ### Outpatients
@@ -195,7 +216,7 @@ params$r$results |>
 #### Attendances
 
 ```{r}
-#| label: pp-impact-of-changes-op-attendances
+#| label: pp-impact-of-changes-overall-op-attendances
 
 params$r$results |>
   possibly_compile_change_factor_data(
@@ -206,6 +227,10 @@ params$r$results |>
     pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
+```
+
+```{r, fig.height=icf_fig_height}
+#| label: pp-impact-of-changes-individual-op-attendances
 
 params$r$results |>
   possibly_compile_indiv_change_factor_data(
@@ -216,13 +241,14 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot()
+  reskit::make_individual_cf_plot() +
+  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
 ```
 
 #### Tele-attendances
 
 ```{r}
-#| label: pp-impact-of-changes-op-tele-attendances
+#| label: pp-impact-of-changes-overall-op-tele-attendances
 
 params$r$results |>
   possibly_compile_change_factor_data(
@@ -233,6 +259,10 @@ params$r$results |>
     pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
+```
+
+```{r, fig.height=icf_fig_height}
+#| label: pp-impact-of-changes-individual-op-tele-attendances
 
 params$r$results |>
   possibly_compile_indiv_change_factor_data(
@@ -243,7 +273,8 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot()
+  reskit::make_individual_cf_plot() +
+  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
 ```
 
 ### A&E
@@ -251,7 +282,7 @@ params$r$results |>
 #### Arrivals
 
 ```{r}
-#| label: pp-impact-of-changes-aae-arrivals
+#| label: pp-impact-of-changes-overall-aae-arrivals
 
 params$r$results |>
   possibly_compile_change_factor_data(
@@ -262,6 +293,10 @@ params$r$results |>
     pod_lookup = reskit::get_principal_pods()
   ) |>
   reskit::make_overall_cf_plot()
+```
+
+```{r, fig.height=icf_fig_height}
+#| label: pp-impact-of-changes-individual-aae-arrivals
 
 params$r$results |>
   possibly_compile_indiv_change_factor_data(
@@ -272,7 +307,8 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot()
+  reskit::make_individual_cf_plot() +
+  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
 ```
 
 ## Activity in detail

--- a/tests/testthat/test-app_server.R
+++ b/tests/testthat/test-app_server.R
@@ -92,13 +92,10 @@ test_that("model_metadata calls get_model_run", {
 
 test_that("selected_data calls get_results_from_azure", {
   m <- mock("results")
-
-  stub(app_server, "get_model_run", list(results_json_gz_path = "file"))
+  stub(app_server, "get_model_run", list(aggregated_results_path = "file"))
   stub(app_server, "get_results_from_azure", m)
   stub(app_server, "get_trust_sites", "trust_sites")
-
   stub(app_server, "mod_info_home_server", "mod_info_home_server")
-
   stub(
     app_server,
     "mod_principal_summary_server",
@@ -109,7 +106,6 @@ test_that("selected_data calls get_results_from_azure", {
     "mod_principal_detailed_server",
     "mod_principal_detailed_server"
   )
-
   stub(
     app_server,
     "mod_model_core_activity_server",
@@ -120,13 +116,10 @@ test_that("selected_data calls get_results_from_azure", {
     "mod_model_results_distribution_server",
     "mod_model_results_distribution_server"
   )
-
   stub(app_server, "mod_info_downloads_server", "mod_info_downloads_server")
   stub(app_server, "mod_info_params_server", "mod_info_params_server")
-
   testServer(app_server, {
     expect_equal(selected_data(), "results")
-
     expect_called(m, 1)
     expect_args(m, 1, "file")
   })

--- a/tests/testthat/test-fct_get_data.R
+++ b/tests/testthat/test-fct_get_data.R
@@ -4,104 +4,74 @@ library(mockery)
 test_that("get_results_from_azure returns data from azure", {
   # arrange
   m0 <- mock("container")
-  m1 <- mock("binary_data")
-  m2 <- mock("decompressed_data")
-  m3 <- mock("json_data")
-  m4 <- mock("json_options")
-  m5 <- mock("parsed_data")
-
+  m1 <- mock("raw_params", "raw_variants")
+  m2 <- mock("patched_params")
+  m3 <- mock("results_data")
   stub(get_results_from_azure, "azkit::get_container", m0)
-  stub(get_results_from_azure, "AzureStor::download_blob", m1)
-  stub(get_results_from_azure, "memDecompress", m2)
-  stub(get_results_from_azure, "yyjsonr::read_json_raw", m3)
-  stub(get_results_from_azure, "yyjsonr::opts_read_json", m4)
-  stub(get_results_from_azure, "parse_results", m5)
-
+  stub(get_results_from_azure, "azkit::read_azure_json", m1)
+  stub(get_results_from_azure, "patch_params", m2)
+  stub(get_results_from_azure, "reskit::read_results_parquet_files", m3)
   withr::local_envvar(
     "AZ_STORAGE_CONTAINER" = "container",
     "AZ_STORAGE_EP" = "ep"
   )
 
   # act
-  actual <- get_results_from_azure("file")
+  actual <- get_results_from_azure("dir")
 
   # assert
   expect_called(m0, 1)
-  expect_called(m1, 1)
+  expect_called(m1, 2)
   expect_called(m2, 1)
   expect_called(m3, 1)
-  expect_called(m4, 1)
-  expect_called(m5, 1)
-
   expect_args(m0, 1, container_name = "container", endpoint_url = "ep")
-  expect_args(m1, 1, "container", "file", NULL)
-  expect_args(m2, 1, "binary_data", type = "gzip")
-  expect_args(m3, 1, "decompressed_data", "json_options")
-  expect_args(m4, 1, "obj_of_arrs_to_df" = FALSE)
-  expect_args(m5, 1, "json_data")
-
-  expect_equal(actual, "parsed_data")
+  expect_args(m1, 1, "container", file.path("dir", "params.json"))
+  expect_args(m1, 2, "container", file.path("dir", "variants.json"))
+  expect_args(m2, 1, "raw_params")
+  expect_args(m3, 1, "container", "dir")
+  expect_equal(
+    actual,
+    list(
+      params = "patched_params",
+      population_variants = "raw_variants",
+      results = "results_data"
+    )
+  )
 })
 
 test_that("get_results_from_local returns data from local storage", {
   # arrange
-  m1 <- mock("json_data")
-  m2 <- mock("json_options")
-  m3 <- mock("parsed_data")
+  m1 <- mock("raw_params", "raw_variants")
+  m2 <- mock("patched_params")
+  m3 <- mock(c("file/a.parquet", "file/b.parquet"))
+  m4 <- mock("parquet_data_a", "parquet_data_b")
 
   stub(get_results_from_local, "yyjsonr::read_json_file", m1)
-  stub(get_results_from_local, "yyjsonr::opts_read_json", m2)
-  stub(get_results_from_local, "parse_results", m3)
+  stub(get_results_from_local, "patch_params", m2)
+  stub(get_results_from_local, "list.files", m3)
+  stub(get_results_from_local, "arrow::read_parquet", m4)
   # act
   actual <- get_results_from_local("file")
 
   # assert
-  expect_called(m1, 1)
+  expect_called(m1, 2)
   expect_called(m2, 1)
   expect_called(m3, 1)
-
-  expect_args(m1, 1, "file", "json_options")
-  expect_args(m2, 1, "obj_of_arrs_to_df" = FALSE)
-  expect_args(m3, 1, "json_data")
-
-  expect_equal(actual, "parsed_data")
-})
-
-test_that("parse_results converts results correctly", {
-  m1 <- mock("patched_results")
-  m2 <- mock("patched_params")
-  stub(parse_results, "patch_results", m1)
-  stub(parse_results, "patch_params", m2)
-
-  data <- list(
-    params = list(param1 = c(1, 2), param2 = list(param3 = c(3, 4))),
-    population_variants = list("a", "b"),
-    results = list(
-      "a" = data.frame(x = c(1, 2)),
-      "b" = data.frame(x = c(3, 4))
+  expect_called(m4, 2)
+  expect_args(m1, 1, file.path("file", "params.json"))
+  expect_args(m1, 2, file.path("file", "variants.json"))
+  expect_args(m2, 1, "raw_params")
+  expect_args(m3, 1, "file", "\\.parquet$", full.names = TRUE)
+  expect_args(m4, 1, "file/a.parquet")
+  expect_args(m4, 2, "file/b.parquet")
+  expect_equal(
+    actual,
+    list(
+      params = "patched_params",
+      population_variants = "raw_variants",
+      results = list(a = "parquet_data_a", b = "parquet_data_b")
     )
   )
-
-  expected <- list(
-    params = "patched_params",
-    population_variants = c("a", "b"),
-    results = list(
-      "a" = tibble::tibble(x = 1:2),
-      "b" = tibble::tibble(x = 3:4)
-    )
-  )
-
-  # act
-  actual <- parse_results(data)
-
-  # assert
-  expect_called(m1, 1)
-  expect_args(m1, 1, expected)
-
-  expect_called(m2, 1)
-  expect_args(m2, 1, data$params)
-
-  expect_equal(actual, "patched_results")
 })
 
 test_that("patch_params returns correct values", {
@@ -119,234 +89,6 @@ test_that("patch_params returns correct values", {
 
   # assert
   expect_equal(actual, expected)
-})
-
-test_that("patch_principal returns correct values (not step_counts)", {
-  # arrange
-  m <- mock()
-
-  stub(patch_principal, "patch_principal_step_counts", m)
-
-  results <- tibble::tibble(
-    model_runs = list(c(1:100))
-  )
-  expected <- dplyr::mutate(
-    results,
-    principal = 50.5,
-    median = 50.5,
-    lwr_pi = 10.9,
-    upr_pi = 90.1
-  )
-
-  # act
-  actual <- patch_principal(results, "x")
-
-  # assert
-  expect_called(m, 0)
-  expect_equal(actual, expected)
-})
-
-test_that("patch_principal returns correct values (step_counts)", {
-  # arrange
-  m <- mock("patch_principal_step_counts")
-
-  stub(patch_principal, "patch_principal_step_counts", m)
-
-  # act
-  actual <- patch_principal("results", "step_counts")
-
-  # assert
-  expect_called(m, 1)
-  expect_args(m, 1, "results")
-  expect_equal(actual, "patch_principal_step_counts")
-})
-
-test_that("patch_principal_step_counts returns correct values", {
-  # arrange
-  results <- tibble::tibble(
-    change_factor = c("baseline", "x"),
-    model_runs = list(1, 2:4)
-  )
-  expected <- results |>
-    dplyr::mutate(value = c(1, 3))
-
-  # act
-  actual <- patch_principal_step_counts(results)
-
-  # assert
-  expect_equal(actual, expected)
-})
-
-test_that("patch_step_counts returns correct values (no strategy)", {
-  # arrange
-  expected <- tibble::tibble(
-    change_factor = "a",
-    strategy = NA_character_,
-    value = 1
-  )
-  r <- list(
-    step_counts = dplyr::select(expected, -"strategy")
-  )
-
-  # act
-  actual <- patch_step_counts(r)
-
-  # assert
-  expect_equal(actual$step_counts, expected)
-})
-
-test_that("patch_step_counts returns correct values (has strategy)", {
-  # arrange
-  expected <- tibble::tibble(
-    change_factor = "a",
-    strategy = "b",
-    value = 1
-  )
-  r <- list(
-    step_counts = expected
-  )
-
-  # act
-  actual <- patch_step_counts(r)
-
-  # assert
-  expect_equal(actual$step_counts, expected)
-})
-
-test_that("patch_results returns correct values", {
-  # arrange
-  r <- list(
-    results = list(
-      "tretspef" = tibble::tribble(
-        ~measure, ~pod, ~tretspef, ~sitetret, ~baseline, ~principal, ~lwr_pi, ~median, ~upr_pi,
-        "a", "op", "100", "s1", 1, 2, 3, 4, 5
-      ),
-      "tretspef+los_group" = tibble::tribble(
-        ~measure, ~pod, ~tretspef, ~sitetret, ~baseline, ~principal, ~lwr_pi, ~median, ~upr_pi, ~los_group,
-        "a", "ip", "100", "s1", 1, 2, 3, 4, 5, "0 days",
-        "b", "ip", "100", "s1", 2, 3, 4, 5, 6, "1 day",
-        "a", "ip", "100", "s1", 3, 4, 5, 6, 7, "2 days",
-        "b", "ip", "100", "s1", 4, 5, 6, 7, 8, "3 days",
-        "a", "ip", "200", "s1", 2, 1, 4, 5, 3, "4-7 days",
-        "a", "ip", "200", "s1", 1, 2, 3, 4, 5, "8-14 days",
-        "a", "ip", "200", "s1", 2, 3, 4, 5, 6, "15-21 days",
-        "a", "ip", "200", "s1", 3, 4, 5, 6, 7, "22+ days",
-        "b", "ip", "200", "s1", 3, 2, 5, 6, 4, "0 days",
-        "a", "ip", "200", "s1", 4, 3, 6, 7, 5, "1 day",
-        "b", "ip", "200", "s1", 5, 4, 7, 8, 6, "2 days",
-        "a", "ip", "100", "s2", 5, 4, 4, 5, 3, "3 days",
-        "b", "ip", "100", "s2", 4, 3, 5, 6, 4, "4-7 days",
-        "b", "ip", "100", "s2", 3, 2, 5, 6, 4, "8-14 days",
-        "b", "ip", "100", "s2", 4, 3, 6, 7, 5, "15-21 days",
-        "b", "ip", "100", "s2", 5, 4, 7, 8, 6, "22+ days",
-        "a", "ip", "100", "s2", 3, 2, 6, 7, 5, "0 days",
-        "b", "ip", "100", "s2", 2, 1, 7, 8, 6, "1 day",
-        "a", "ip", "200", "s2", 4, 5, 5, 6, 1, "2 days",
-        "b", "ip", "200", "s2", 3, 4, 6, 7, 2, "3 days",
-        "a", "ip", "200", "s2", 2, 3, 7, 8, 3, "4-7 days",
-        "a", "ip", "200", "s2", 3, 2, 6, 7, 5, "8-14 days",
-        "a", "ip", "200", "s2", 2, 1, 7, 8, 6, "15-21 days",
-        "a", "ip", "200", "s2", 4, 5, 5, 6, 1, "22+ days",
-      ),
-      "sex+age_group" = tibble::tribble(
-        ~sitetret, ~pod, ~sex, ~age_group, ~measure, ~baseline, ~principal, ~median, ~lwr_pi, ~upr_pi,
-        "s1", "ip", 1, "0", "a", 1, 2, 4, 3, 5,
-        "s1", "ip", 1, "85+", "b", 2, 3, 5, 4, 6,
-        "s1", "ip", 1, "65-74", "a", 4, 5, 7, 6, 8,
-        "s1", "ip", 1, "16-17", "b", 2, 1, 5, 4, 3,
-        "s1", "ip", 1, "18-34", "a", 3, 2, 6, 5, 4,
-        "s1", "ip", 1, "35-49", "b", 4, 3, 7, 6, 5,
-        "s1", "ip", 1, "5-9", "a", 3, 4, 6, 5, 7,
-        "s1", "ip", 1, "50-64", "b", 5, 4, 8, 7, 6,
-        "s2", "ip", 1, "10-15", "a", 5, 4, 5, 4, 3,
-        "s2", "ip", 1, "75-84", "b", 4, 3, 6, 5, 4,
-        "s2", "ip", 1, "1-4", "a", 3, 2, 7, 6, 5,
-        "s2", "ip", 1, "Unknown", "b", 2, 1, 8, 7, 6
-      )
-    )
-  )
-  m <- mock(r$results[[1]], r$results[[2]], r$results[[3]], r$results)
-  stub(patch_results, "patch_principal", m)
-  stub(patch_results, "patch_step_counts", m)
-
-  expected <- list(
-    results = list(
-      "tretspef" = tibble::tribble(
-        ~measure, ~pod, ~tretspef, ~sitetret, ~baseline, ~principal, ~lwr_pi, ~median, ~upr_pi,
-        "a", "op", "100", "s1", 1, 2, 3, 4, 5
-      ),
-      "tretspef+los_group" = r$results[["tretspef+los_group"]] |>
-        dplyr::mutate(
-          dplyr::across(
-            "los_group",
-            \(.x) {
-              forcats::fct_relevel(
-                .x,
-                c(
-                  "0 days",
-                  "1 day",
-                  "2 days",
-                  "3 days",
-                  "4-7 days",
-                  "8-14 days",
-                  "15-21 days",
-                  "22+ days"
-                )
-              )
-            }
-          )
-        ) |>
-        dplyr::arrange(
-          .data$pod,
-          .data$measure,
-          .data$sitetret,
-          .data$los_group
-        ),
-      "sex+age_group" = r$results[["sex+age_group"]] |>
-        dplyr::mutate(
-          dplyr::across(
-            "age_group",
-            \(.x) {
-              forcats::lvls_expand(
-                .x,
-                c(
-                  "0",
-                  "1-4",
-                  "5-9",
-                  "10-15",
-                  "16-17",
-                  "18-34",
-                  "35-49",
-                  "50-64",
-                  "65-74",
-                  "75-84",
-                  "85+",
-                  "Unknown"
-                )
-              )
-            }
-          )
-        ) |>
-        dplyr::arrange(
-          .data$pod,
-          .data$measure,
-          .data$sitetret,
-          .data$sex,
-          .data$age_group
-        )
-    )
-  )
-
-  # act
-  actual <- patch_results(r)
-
-  # assert
-  expect_equal(actual, expected)
-  expect_called(m, 4)
-  expect_args(m, 1, r$results[[1]], "tretspef")
-  expect_args(m, 2, r$results[[2]], "tretspef+los_group")
-  expect_args(m, 3, r$results[[3]], "sex+age_group")
-  expect_args(m, 4, r$results)
 })
 
 test_that("user_allowed_datasets returns correct values", {
@@ -424,23 +166,67 @@ test_that("get_principal_high_level gets the results", {
   r <- list(
     results = list(
       default = tibble::tribble(
-        ~pod, ~sitetret, ~baseline, ~principal, ~measure,
-        "aae_1", "a", 1, 2, "attendances",
-        "aae_2", "a", 2, 4, "attendances",
-        "ip_1", "a", 5, 6, "admissions",
-        "ip_2", "a", 7, 8, "beddays",
-        "ip_3", "a", 9, 10, "procedures",
-        "op_1", "a", 9, 10, "attendances",
-        "op_2", "a", 11, 12, "tele_attendances"
+        ~pod,
+        ~sitetret,
+        ~baseline,
+        ~principal,
+        ~measure,
+        "aae_1",
+        "a",
+        1,
+        2,
+        "attendances",
+        "aae_2",
+        "a",
+        2,
+        4,
+        "attendances",
+        "ip_1",
+        "a",
+        5,
+        6,
+        "admissions",
+        "ip_2",
+        "a",
+        7,
+        8,
+        "beddays",
+        "ip_3",
+        "a",
+        9,
+        10,
+        "procedures",
+        "op_1",
+        "a",
+        9,
+        10,
+        "attendances",
+        "op_2",
+        "a",
+        11,
+        12,
+        "tele_attendances"
       )
     )
   )
 
   expected <- tibble::tribble(
-    ~pod, ~sitetret, ~baseline, ~principal,
-    "aae", "a", 3, 6,
-    "ip_1", "a", 5, 6,
-    "op_1", "a", 9, 10
+    ~pod,
+    ~sitetret,
+    ~baseline,
+    ~principal,
+    "aae",
+    "a",
+    3,
+    6,
+    "ip_1",
+    "a",
+    5,
+    6,
+    "op_1",
+    "a",
+    9,
+    10
   )
 
   actual <- get_principal_high_level(
@@ -497,20 +283,65 @@ test_that("get_model_run_distribution gets the results", {
   r <- list(
     results = list(
       default = tibble::tribble(
-        ~sitetret, ~baseline, ~principal, ~model_runs, ~pod, ~measure,
-        "a", 100, 110, c(100, 200, 300), "a", "a",
-        "a", 101, 111, c(101, 201, 301), "a", "b",
-        "a", 102, 112, c(102, 202, 302), "b", "a",
-        "a", 103, 113, c(103, 203, 303), "b", "b"
+        ~sitetret,
+        ~baseline,
+        ~principal,
+        ~model_runs,
+        ~pod,
+        ~measure,
+        "a",
+        100,
+        110,
+        c(100, 200, 300),
+        "a",
+        "a",
+        "a",
+        101,
+        111,
+        c(101, 201, 301),
+        "a",
+        "b",
+        "a",
+        102,
+        112,
+        c(102, 202, 302),
+        "b",
+        "a",
+        "a",
+        103,
+        113,
+        c(103, 203, 303),
+        "b",
+        "b"
       )
     )
   )
 
   expected <- tibble::tribble(
-    ~sitetret, ~baseline, ~principal, ~model_run, ~value, ~variant,
-    "a", 100, 110, 1, 100, "a",
-    "a", 100, 110, 2, 200, "a",
-    "a", 100, 110, 3, 300, "b"
+    ~sitetret,
+    ~baseline,
+    ~principal,
+    ~model_run,
+    ~value,
+    ~variant,
+    "a",
+    100,
+    110,
+    1,
+    100,
+    "a",
+    "a",
+    100,
+    110,
+    2,
+    200,
+    "a",
+    "a",
+    100,
+    110,
+    3,
+    300,
+    "b"
   )
 
   actual <- get_model_run_distribution(r, "a", "a", "a")
@@ -599,19 +430,37 @@ test_that("get_principal_change_factors validates the arguments", {
 
 test_that("trust_site_aggregation adds in a trust level aggregatrion", {
   df <- tibble::tribble(
-    ~sitetret, ~x, ~v,
-    "x", "a", 1,
-    "x", "b", 2,
-    "y", "b", 3,
-    "x", "c", 4,
-    "y", "c", 5
+    ~sitetret,
+    ~x,
+    ~v,
+    "x",
+    "a",
+    1,
+    "x",
+    "b",
+    2,
+    "y",
+    "b",
+    3,
+    "x",
+    "c",
+    4,
+    "y",
+    "c",
+    5
   )
 
   expected <- dplyr::bind_rows(
     tibble::tribble(
-      ~sitetret, ~x, ~v,
-      "trust", "b", 5,
-      "trust", "c", 9
+      ~sitetret,
+      ~x,
+      ~v,
+      "trust",
+      "b",
+      5,
+      "trust",
+      "c",
+      9
     ),
     df
   ) |>

--- a/tests/testthat/test-mod_info_downloads.R
+++ b/tests/testthat/test-mod_info_downloads.R
@@ -6,8 +6,16 @@ library(mockery)
 # ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 atpmo_expected <- tibble::tribble(
-  ~activity_type, ~activity_type_name, ~pod, ~pod_name, ~measures,
-  "aae", "A&E", "aae_type-01", "Type 1 Department", "ambulance"
+  ~activity_type,
+  ~activity_type_name,
+  ~pod,
+  ~pod_name,
+  ~measures,
+  "aae",
+  "A&E",
+  "aae_type-01",
+  "Type 1 Department",
+  "ambulance"
 )
 
 set_names <- function(x) {
@@ -138,8 +146,8 @@ test_that("it sets up download handlers", {
     {
       session$private$flush()
       expect_called(m, 2)
-      expect_args(m, 1, selected_data)
-      expect_args(m, 2, selected_data)
+      expect_args(m, 1, reshaped_data)
+      expect_args(m, 2, reshaped_data)
     }
   )
 })


### PR DESCRIPTION
Close #265, close #371, close #391.

* Adjusted `get_results_from_azure()` to read from the results-directory path extracted from ATS (no longer the zipped json).
* Did the same for `get_results_from_local()` and introduced an empty `inst/sample_params/` to be populated by the developer.
* Updated data preparation for downloadable reports and results files.
* Controlled manually the height of ICF plots in the output report (a quick fix for #427).
* Removed `shim_results()` calls.
* Amended tests to they passed (did not add new ones, techdebt already recorded in #132 and #417).

This took longer than I thought, mostly due to the downloads. Definitely can codewalk this if required.

Also copying @francisbarton for interest.