### PR TITLE
Pin {reskit} version and regenerate manifest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     markdown,
     plotly,
     purrr,
-    reskit (>= 1.0.1),
+    reskit (== 1.0.1),
     rlang,
     rmarkdown,
     scales,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "en_GB",
-  "platform": "4.6.0",
+  "platform": "4.5.3",
   "metadata": {
     "appmode": "shiny",
     "primary_rmd": null,
@@ -17,7 +17,7 @@
   "packages": {
     "AzureAuth": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "AzureAuth",
         "Title": "Authentication Services for Azure Active Directory",
@@ -36,15 +36,14 @@
         "Packaged": "2025-12-20 11:49:02 UTC; hongo",
         "Author": "Hong Ooi [aut, cre],\n  Tyler Littlefield [ctb],\n  httr development team [ctb] (Original OAuth listener code),\n  Scott Holden [ctb] (Advice on AAD authentication),\n  Chris Stone [ctb] (Advice on AAD authentication),\n  Microsoft [cph]",
         "Maintainer": "Hong Ooi <hongooi73@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-20 12:10:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-25 16:08:07 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:57:46 UTC; windows"
       }
     },
     "AzureGraph": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "AzureGraph",
         "Title": "Simple Interface to 'Microsoft Graph'",
@@ -63,15 +62,14 @@
         "Packaged": "2025-07-31 13:03:35 UTC; hongo",
         "Author": "Hong Ooi [aut, cre],\n  Microsoft [cph]",
         "Maintainer": "Hong Ooi <hongooi73@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-07-31 13:50:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-25 16:12:42 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 04:14:08 UTC; windows"
       }
     },
     "AzureRMR": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "AzureRMR",
         "Title": "Interface to 'Azure Resource Manager'",
@@ -90,15 +88,14 @@
         "Packaged": "2025-07-31 14:39:55 UTC; hongo",
         "Author": "Hong Ooi [aut, cre],\n  Microsoft [cph]",
         "Maintainer": "Hong Ooi <hongooi73@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-07-31 15:10:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-25 16:17:00 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 04:35:52 UTC; windows"
       }
     },
     "AzureStor": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "AzureStor",
         "Title": "Storage Management in 'Azure'",
@@ -117,15 +114,14 @@
         "Packaged": "2025-08-25 09:25:20 UTC; hongo",
         "Author": "Hong Ooi [aut, cre],\n  Microsoft [cph]",
         "Maintainer": "Hong Ooi <hongooi73@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-08-25 10:00:10 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-25 16:31:16 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 04:59:18 UTC; windows"
       }
     },
     "R6": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "R6",
         "Title": "Encapsulated Classes with Reference Semantics",
@@ -145,14 +141,14 @@
         "Packaged": "2025-02-14 21:15:19 UTC; winston",
         "Author": "Winston Chang [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-02-15 00:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:25:54 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:20 UTC; windows"
       }
     },
     "RColorBrewer": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "RColorBrewer",
         "Version": "1.1-3",
@@ -166,15 +162,14 @@
         "License": "Apache License 2.0",
         "Packaged": "2022-04-03 10:26:20 UTC; neuwirth",
         "NeedsCompilation": "no",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2022-04-03 19:20:13 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-24 05:25:57 UTC; unix"
+        "Built": "R 4.5.2; ; 2025-11-01 00:30:56 UTC; windows"
       }
     },
     "Rcpp": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "Rcpp",
         "Title": "Seamless R and C++ Integration",
@@ -196,15 +191,21 @@
         "Packaged": "2026-04-23 14:12:31 UTC; edd",
         "Author": "Dirk Eddelbuettel [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-6419-907X>),\n  Romain Francois [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>),\n  JJ Allaire [aut] (ORCID: <https://orcid.org/0000-0003-0174-9868>),\n  Kevin Ushey [aut] (ORCID: <https://orcid.org/0000-0003-2880-7407>),\n  Qiang Kou [aut] (ORCID: <https://orcid.org/0000-0001-6786-5453>),\n  Nathan Russell [aut],\n  Iñaki Ucar [aut] (ORCID: <https://orcid.org/0000-0001-6403-5550>),\n  Doug Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>),\n  John Chambers [aut]",
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-24 05:30:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 13:53:46 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:52:59 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "Rcpp",
+        "RemoteRef": "Rcpp",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.1.1-1.1"
       }
     },
     "S7": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "S7",
         "Title": "An Object Oriented System Meant to Become a Successor to S3 and\nS4",
@@ -229,15 +230,21 @@
         "Packaged": "2026-04-20 21:37:20 UTC; hadleywickham",
         "Author": "Object-Oriented Programming Working Group [cph],\n  Davis Vaughan [aut],\n  Jim Hester [aut] (ORCID: <https://orcid.org/0000-0002-2739-7082>),\n  Tomasz Kalinowski [aut],\n  Will Landau [aut],\n  Michael Lawrence [aut],\n  Martin Maechler [aut] (ORCID: <https://orcid.org/0000-0002-8685-9910>),\n  Luke Tierney [aut],\n  Hadley Wickham [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4757-117X>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-22 11:00:10 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:54 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:52:56 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "S7",
+        "RemoteRef": "S7",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.2.2"
       }
     },
     "V8": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "V8",
         "Type": "Package",
@@ -261,15 +268,21 @@
         "Packaged": "2026-04-19 11:38:23 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  George Stagg [ctb] (ORCID: <https://orcid.org/0009-0006-3173-9846>),\n  Jan Marvin Garbuszus [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-21 05:10:34 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 15:40:41 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_27"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:55:04 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "V8",
+        "RemoteRef": "V8",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "8.2.0"
       }
     },
     "arrow": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "arrow",
         "Title": "Integration to 'Apache' 'Arrow'",
@@ -295,15 +308,21 @@
         "Packaged": "2026-04-27 03:37:21 UTC; bryce",
         "Author": "Neal Richardson [aut],\n  Ian Cook [aut],\n  Nic Crane [aut],\n  Dewey Dunnington [aut] (ORCID: <https://orcid.org/0000-0002-9415-4582>),\n  Romain François [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>),\n  Jonathan Keane [aut, cre],\n  Bryce Mecum [aut],\n  Dragoș Moldovan-Grünfeld [aut],\n  Jeroen Ooms [aut],\n  Jacob Wujciak-Jens [aut],\n  Javier Luraschi [ctb],\n  Karl Dunkle Werner [ctb] (ORCID:\n    <https://orcid.org/0000-0003-0523-7309>),\n  Jeffrey Wong [ctb],\n  Apache Arrow [aut, cph]",
         "Maintainer": "Jonathan Keane <jkeane@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-29 13:00:15 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-30 07:21:18 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_28"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 17:41:59 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "arrow",
+        "RemoteRef": "arrow",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "24.0.0"
       }
     },
     "askpass": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "askpass",
         "Type": "Package",
@@ -323,15 +342,15 @@
         "Packaged": "2024-10-03 14:12:09 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-10-04 07:20:03 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:36 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:59:49 UTC; windows",
+        "Archs": "x64"
       }
     },
     "assertthat": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "assertthat",
         "Title": "Easy Pre and Post Assertions",
@@ -347,15 +366,14 @@
         "Packaged": "2019-03-21 13:11:01 UTC; hadley",
         "Author": "Hadley Wickham [aut, cre]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2019-03-21 14:53:46 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-24 05:25:52 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:04:24 UTC; windows"
       }
     },
     "attempt": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "attempt",
         "Title": "Tools for Defensive Programming",
@@ -374,9 +392,9 @@
         "Packaged": "2020-05-03 20:24:38 UTC; colin",
         "Author": "Colin Fay [aut, cre] (<https://orcid.org/0000-0001-7343-1846>)",
         "Maintainer": "Colin Fay <contact@colinfay.me>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2020-05-03 20:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:45 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-04-14 01:29:02 UTC; windows"
       }
     },
     "azkit": {
@@ -399,24 +417,24 @@
         "RemoteType": "github",
         "RemoteHost": "api.github.com",
         "RemoteRepo": "azkit",
-        "RemoteUsername": "the-strategy-unit",
-        "RemotePkgRef": "the-strategy-unit/azkit",
+        "RemoteUsername": "The-Strategy-Unit",
+        "RemotePkgRef": "The-Strategy-Unit/azkit",
         "RemoteRef": "HEAD",
-        "RemoteSha": "98e6a2a2d551b8365b6acac5d587f7f5c04362c4",
+        "RemoteSha": "1801fc6af1d9bf0f95e253cc620036374c3a1d58",
         "GithubRepo": "azkit",
-        "GithubUsername": "the-strategy-unit",
+        "GithubUsername": "The-Strategy-Unit",
         "GithubRef": "HEAD",
-        "GithubSHA1": "98e6a2a2d551b8365b6acac5d587f7f5c04362c4",
+        "GithubSHA1": "1801fc6af1d9bf0f95e253cc620036374c3a1d58",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-20 15:06:39 UTC; tom",
+        "Packaged": "2026-06-12 08:43:59 UTC; Matt.Dray",
         "Author": "Fran Barton [aut, cre] (ORCID: <https://orcid.org/0000-0002-5650-1176>),\n  Tom Jemmett [ctb]",
         "Maintainer": "Fran Barton <francis.barton@nhs.net>",
-        "Built": "R 4.6.0; ; 2026-05-20 15:06:39 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-06-12 08:44:00 UTC; windows"
       }
     },
     "base64enc": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "base64enc",
         "Version": "0.1-6",
@@ -432,16 +450,15 @@
         "BugReports": "https://github.com/s-u/base64enc/issues",
         "NeedsCompilation": "yes",
         "Packaged": "2026-02-02 01:51:07 UTC; rforge",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-02-02 06:31:10 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:52 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-02-06 00:51:45 UTC; windows",
+        "Archs": "x64"
       }
     },
     "beeswarm": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "beeswarm",
         "Title": "The Bee Swarm Plot, an Alternative to Stripchart",
@@ -457,16 +474,15 @@
         "Packaged": "2021-05-07 08:52:45 UTC; aron",
         "Author": "Aron Eklund [aut, cre] (<https://orcid.org/0000-0003-0861-1001>),\n  James Trimble [aut] (<https://orcid.org/0000-0001-7282-8745>)",
         "Maintainer": "Aron Eklund <aroneklund@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2021-06-01 21:40:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 14:58:37 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2025-11-01 00:38:58 UTC; windows",
+        "Archs": "x64"
       }
     },
     "bigD": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "bigD",
@@ -487,14 +503,14 @@
         "Packaged": "2025-04-03 13:52:40 UTC; riannone",
         "Author": "Richard Iannone [aut, cre] (<https://orcid.org/0000-0003-3925-190X>),\n  Olivier Roy [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Richard Iannone <rich@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-04-03 14:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:00:28 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:04:45 UTC; windows"
       }
     },
     "bit": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "bit",
         "Title": "Classes and Methods for Fast Memory-Efficient Boolean Selections",
@@ -515,19 +531,19 @@
         "Packaged": "2025-03-05 07:18:45 UTC; michael",
         "Author": "Michael Chirico [aut, cre],\n  Jens Oehlschlägel [aut],\n  Brian Ripley [ctb]",
         "Maintainer": "Michael Chirico <MichaelChirico4@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-06 10:50:01 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:54 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-08-04 00:20:05 UTC; windows",
+        "Archs": "x64"
       }
     },
     "bit64": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "bit64",
         "Title": "A S3 Class for Vectors of 64bit Integers",
-        "Version": "4.8.0",
+        "Version": "4.8.2",
         "Authors@R": "c(\n    person(\"Michael\", \"Chirico\", email=\"michaelchirico4@gmail.com\", role=c(\"aut\", \"cre\")),\n    person(\"Jens\", \"Oehlschlägel\", role=\"aut\"),\n    person(\"Leonardo\", \"Silvestri\", role=\"ctb\"),\n    person(\"Ofek\", \"Shilon\", role=\"ctb\"),\n    person(\"Christian\", \"Ullerich\", role=\"ctb\")\n  )",
         "Depends": "R (>= 3.5.0)",
         "Description": "\n  Package 'bit64' provides serializable S3 atomic 64bit (signed) integers.\n  These are useful for handling database keys and exact counting in +-2^63.\n  WARNING: do not use them as replacement for 32bit integers, integer64 are not\n  supported for subscripting by R-core and they have different semantics when\n  combined with double, e.g. integer64 + double => integer64.\n  Class integer64 can be used in vectors, matrices, arrays and data.frames.\n  Methods are available for coercion from and to logicals, integers, doubles,\n  characters and factors as well as many elementwise and summary functions.\n  Many fast algorithmic operations such as 'match' and 'order' support inter-\n  active data exploration and manipulation and optionally leverage caching.",
@@ -543,18 +559,25 @@
         "Config/Needs/website": "tidyverse/tidytemplate",
         "RoxygenNote": "7.3.3",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-04-20 06:52:55 UTC; michael",
+        "Packaged": "2026-05-19 05:37:05 UTC; chiricom",
         "Author": "Michael Chirico [aut, cre],\n  Jens Oehlschlägel [aut],\n  Leonardo Silvestri [ctb],\n  Ofek Shilon [ctb],\n  Christian Ullerich [ctb]",
         "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
         "Repository": "RSPM",
-        "Date/Publication": "2026-04-21 06:10:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:32 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Date/Publication": "2026-05-19 09:40:02 UTC",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2026-05-20 05:40:30 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "bit64",
+        "RemotePkgRef": "bit64",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "4.8.2"
       }
     },
     "bitops": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "bitops",
         "Version": "1.0-9",
@@ -569,16 +592,15 @@
         "Packaged": "2024-10-03 09:17:35 UTC; maechler",
         "Author": "Steve Dutky [aut] (S original; then (after MM's port) revised and\n    modified),\n  Martin Maechler [cre, aut] (Initial R port; tweaks,\n    <https://orcid.org/0000-0002-8685-9910>)",
         "Maintainer": "Martin Maechler <maechler@stat.math.ethz.ch>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-10-03 23:00:54 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:54 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2025-11-01 00:32:16 UTC; windows",
+        "Archs": "x64"
       }
     },
     "bs4Dash": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "bs4Dash",
@@ -602,20 +624,20 @@
         "NeedsCompilation": "no",
         "Packaged": "2025-08-25 10:33:25 UTC; davidgranjon",
         "Author": "David Granjon [aut, cre],\n  RinteRface [cph],\n  Almasaeed Studio [ctb, cph] (AdminLTE3 theme for Bootstrap 4),\n  Winston Chang [ctb, cph] (Utils functions from shinydashboard)",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-08-25 11:10:14 UTC",
-        "Built": "R 4.6.0; ; 2026-05-09 04:19:46 UTC; unix",
+        "Built": "R 4.5.3; ; 2026-05-16 19:15:54 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "bs4Dash",
         "RemoteRef": "bs4Dash",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
         "RemoteSha": "2.3.5"
       }
     },
     "bslib": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "bslib",
         "Title": "Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'",
@@ -643,18 +665,19 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2026-05-16 08:10:07 UTC",
-        "Built": "R 4.6.0; ; 2026-05-17 05:24:23 UTC; unix",
+        "Built": "R 4.5.0; ; 2026-05-17 05:32:49 UTC; windows",
         "RemoteType": "standard",
-        "RemotePkgRef": "bslib",
         "RemoteRef": "bslib",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
+        "RemotePkgRef": "bslib",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.11.0"
       }
     },
     "cachem": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "cachem",
         "Version": "1.1.0",
@@ -674,44 +697,51 @@
         "Packaged": "2024-05-15 15:54:22 UTC; winston",
         "Author": "Winston Chang [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-05-16 09:50:11 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:46 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:59:43 UTC; windows",
+        "Archs": "x64"
       }
     },
     "callr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "callr",
         "Title": "Call R from R",
-        "Version": "3.7.6",
-        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\", \"cph\"),\n           comment = c(ORCID = \"0000-0001-7098-9676\")),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n    person(\"Ascent Digital Services\", role = c(\"cph\", \"fnd\"))\n  )",
+        "Version": "3.8.0",
+        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\", \"cph\"),\n           comment = c(ORCID = \"0000-0001-7098-9676\")),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\")),\n    person(\"Ascent Digital Services\", role = c(\"cph\", \"fnd\"))\n  )",
         "Description": "It is sometimes useful to perform a computation in a separate\n    R process, without affecting the current R process at all.  This\n    packages does exactly that.",
         "License": "MIT + file LICENSE",
         "URL": "https://callr.r-lib.org, https://github.com/r-lib/callr",
         "BugReports": "https://github.com/r-lib/callr/issues",
         "Depends": "R (>= 3.4)",
-        "Imports": "processx (>= 3.6.1), R6, utils",
-        "Suggests": "asciicast (>= 2.3.1), cli (>= 1.1.0), mockery, ps, rprojroot,\nspelling, testthat (>= 3.2.0), withr (>= 2.3.0)",
+        "Imports": "otel (>= 0.2.0), processx (>= 3.6.1), R6, utils",
+        "Suggests": "asciicast (>= 2.3.1), carrier, cli (>= 1.1.0), otelsdk (>=\n0.2.0), ps, rprojroot, spelling, testthat (>= 3.2.0), withr (>=\n2.3.0)",
         "Config/Needs/website": "r-lib/asciicast, glue, htmlwidgets, igraph,\ntibble, tidyverse/tidytemplate",
         "Config/testthat/edition": "3",
+        "Config/usethis/last-upkeep": "2025-04-28",
         "Encoding": "UTF-8",
         "Language": "en-US",
-        "RoxygenNote": "7.3.1.9000",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "no",
-        "Packaged": "2024-03-25 12:10:25 UTC; gaborcsardi",
-        "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Ascent Digital Services [cph, fnd]",
+        "Packaged": "2026-06-05 08:20:00 UTC; gaborcsardi",
+        "Author": "Gábor Csárdi [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "RSPM",
-        "Date/Publication": "2024-03-25 13:30:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:16 UTC; unix"
+        "Repository": "CRAN",
+        "Date/Publication": "2026-06-05 11:40:13 UTC",
+        "Built": "R 4.5.3; ; 2026-06-10 02:30:40 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "callr",
+        "RemoteRef": "callr",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
+        "RemoteSha": "3.8.0"
       }
     },
     "cli": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "cli",
         "Title": "Helpers for Developing Command Line Interfaces",
@@ -733,15 +763,21 @@
         "Packaged": "2026-04-08 18:14:45 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Hadley Wickham [ctb],\n  Kirill Müller [ctb],\n  Salim Brüggemann [ctb] (ORCID: <https://orcid.org/0000-0002-5329-5987>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Gábor Csárdi <gabor@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-09 09:50:18 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:54 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:52:56 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "cli",
+        "RemoteRef": "cli",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "3.6.6"
       }
     },
     "commonmark": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "commonmark",
         "Type": "Package",
@@ -760,15 +796,15 @@
         "Packaged": "2025-07-07 13:20:39 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  John MacFarlane [cph] (Author of cmark)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-07-07 13:40:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:58 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:03:21 UTC; windows",
+        "Archs": "x64"
       }
     },
     "config": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "config",
         "Type": "Package",
@@ -790,14 +826,14 @@
         "Packaged": "2023-08-30 09:28:23 UTC; apdev",
         "Author": "JJ Allaire [aut],\n  Andrie de Vries [cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Andrie de Vries <apdevries@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-08-30 16:50:36 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:49 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:06:04 UTC; windows"
       }
     },
     "cpp11": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "cpp11",
         "Title": "A C++11 Interface for R's C Interface",
@@ -819,14 +855,14 @@
         "Packaged": "2026-05-06 12:49:17 UTC; davis",
         "Author": "Davis Vaughan [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4777-038X>),\n  Jim Hester [aut] (ORCID: <https://orcid.org/0000-0002-2739-7082>),\n  Romain François [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>),\n  Benjamin Kietzman [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-05-06 14:40:12 UTC",
-        "Built": "R 4.6.0; ; 2026-05-08 20:38:03 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-05-26 11:04:27 UTC; windows"
       }
     },
     "crosstalk": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "crosstalk",
@@ -846,20 +882,14 @@
         "Packaged": "2025-08-26 22:06:47 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Posit Software, PBC [cph, fnd],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Kristopher Michael Kowal [ctb, cph] (es5-shim library),\n  es5-shim contributors [ctb, cph] (es5-shim library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-08-26 23:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-05-09 05:04:54 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "crosstalk",
-        "RemoteRef": "crosstalk",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "1.2.2"
+        "Built": "R 4.5.3; ; 2026-04-14 02:34:45 UTC; windows"
       }
     },
     "curl": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "curl",
         "Type": "Package",
@@ -881,15 +911,21 @@
         "Packaged": "2026-04-21 14:47:54 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  Hadley Wickham [ctb],\n  Posit Software, PBC [cph]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-22 09:40:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:26 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_27"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:53:07 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "curl",
+        "RemoteRef": "curl",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "7.1.0"
       }
     },
     "data.table": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "data.table",
         "Version": "1.18.4",
@@ -909,15 +945,21 @@
         "Packaged": "2026-05-05 05:46:53 UTC; a00932230",
         "Author": "Tyson Barrett [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-2137-1391>),\n  Matt Dowle [aut],\n  Arun Srinivasan [aut],\n  Jan Gorecki [aut],\n  Michael Chirico [aut] (ORCID: <https://orcid.org/0000-0003-0787-087X>),\n  Toby Hocking [aut] (ORCID: <https://orcid.org/0000-0002-3146-0865>),\n  Benjamin Schwendinger [aut] (ORCID:\n    <https://orcid.org/0000-0003-3315-8114>),\n  Ivan Krylov [aut] (ORCID: <https://orcid.org/0000-0002-0172-3812>),\n  Pasha Stetsenko [ctb],\n  Tom Short [ctb],\n  Steve Lianoglou [ctb],\n  Eduard Antonyan [ctb],\n  Markus Bonsch [ctb],\n  Hugh Parsonage [ctb],\n  Scott Ritchie [ctb],\n  Kun Ren [ctb],\n  Xianying Tan [ctb],\n  Rick Saporta [ctb],\n  Otto Seiskari [ctb],\n  Xianghui Dong [ctb],\n  Michel Lang [ctb],\n  Watal Iwasaki [ctb],\n  Seth Wenchel [ctb],\n  Karl Broman [ctb],\n  Tobias Schmidt [ctb],\n  David Arenburg [ctb],\n  Ethan Smith [ctb],\n  Francois Cocquemas [ctb],\n  Matthieu Gomez [ctb],\n  Philippe Chataignon [ctb],\n  Nello Blaser [ctb],\n  Dmitry Selivanov [ctb],\n  Andrey Riabushenko [ctb],\n  Cheng Lee [ctb],\n  Declan Groves [ctb],\n  Daniel Possenriede [ctb],\n  Felipe Parages [ctb],\n  Denes Toth [ctb],\n  Mus Yaramaz-David [ctb],\n  Ayappan Perumal [ctb],\n  James Sams [ctb],\n  Martin Morgan [ctb],\n  Michael Quinn [ctb],\n  @javrucebo [ctb] (GitHub user),\n  Marc Halperin [ctb],\n  Roy Storey [ctb],\n  Manish Saraswat [ctb],\n  Morgan Jacob [ctb],\n  Michael Schubmehl [ctb],\n  Davis Vaughan [ctb],\n  Leonardo Silvestri [ctb],\n  Jim Hester [ctb],\n  Anthony Damico [ctb],\n  Sebastian Freundt [ctb],\n  David Simons [ctb],\n  Elliott Sales de Andrade [ctb],\n  Cole Miller [ctb],\n  Jens Peder Meldgaard [ctb],\n  Vaclav Tlapak [ctb],\n  Kevin Ushey [ctb],\n  Dirk Eddelbuettel [ctb],\n  Tony Fischetti [ctb],\n  Ofek Shilon [ctb],\n  Vadim Khotilovich [ctb],\n  Hadley Wickham [ctb],\n  Bennet Becker [ctb],\n  Kyle Haynes [ctb],\n  Boniface Christian Kamgang [ctb],\n  Olivier Delmarcell [ctb],\n  Josh O'Brien [ctb],\n  Dereck de Mezquita [ctb],\n  Michael Czekanski [ctb],\n  Dmitry Shemetov [ctb],\n  Nitish Jha [ctb],\n  Joshua Wu [ctb],\n  Iago Giné-Vázquez [ctb],\n  Anirban Chetia [ctb],\n  Doris Amoakohene [ctb],\n  Angel Feliz [ctb],\n  Michael Young [ctb],\n  Mark Seeto [ctb],\n  Philippe Grosjean [ctb],\n  Vincent Runge [ctb],\n  Christian Wia [ctb],\n  Elise Maigné [ctb],\n  Vincent Rocher [ctb],\n  Vijay Lulla [ctb],\n  Aljaž Sluga [ctb],\n  Bill Evans [ctb],\n  Reino Bruner [ctb],\n  @badasahog [ctb] (GitHub user),\n  Vinit Thakur [ctb],\n  Mukul Kumar [ctb],\n  Ildikó Czeller [ctb],\n  Manmita Das [ctb],\n  Tarun Thammisetty [ctb]",
         "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-05-06 05:10:20 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-05-08 20:37:33 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-06 14:51:54 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "data.table",
+        "RemoteRef": "data.table",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.18.4"
       }
     },
     "desc": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "desc",
         "Title": "Manipulate DESCRIPTION Files",
@@ -940,14 +982,14 @@
         "NeedsCompilation": "no",
         "Packaged": "2023-12-10 11:07:50 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Kirill Müller [aut],\n  Jim Hester [aut],\n  Maëlle Salmon [ctb] (<https://orcid.org/0000-0002-2815-0399>),\n  Posit Software, PBC [cph, fnd]",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-12-10 11:40:08 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:37 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:59:49 UTC; windows"
       }
     },
     "digest": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "digest",
         "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\",\n                    comment = c(ORCID = \"0000-0001-6419-907X\")),\n             person(\"Antoine\", \"Lucas\", role=\"ctb\", comment = c(ORCID = \"0000-0002-8059-9767\")),\n             person(\"Jarek\", \"Tuszynski\", role=\"ctb\"),\n             person(\"Henrik\", \"Bengtsson\", role=\"ctb\", comment = c(ORCID = \"0000-0002-7579-5165\")),\n             person(\"Simon\", \"Urbanek\", role=\"ctb\", comment = c(ORCID = \"0000-0003-2297-1732\")),\n             person(\"Mario\", \"Frasca\", role=\"ctb\"),\n             person(\"Bryan\", \"Lewis\", role=\"ctb\"),\n             person(\"Murray\", \"Stokely\", role=\"ctb\"),\n             person(\"Hannes\", \"Muehleisen\", role=\"ctb\", comment = c(ORCID = \"0000-0001-8552-0029\")),\n             person(\"Duncan\", \"Murdoch\", role=\"ctb\"),\n             person(\"Jim\", \"Hester\", role=\"ctb\", comment = c(ORCID = \"0000-0002-2739-7082\")),\n             person(\"Wush\", \"Wu\", role=\"ctb\", comment = c(ORCID = \"0000-0001-5180-0567\")),\n             person(\"Qiang\", \"Kou\", role=\"ctb\", comment = c(ORCID = \"0000-0001-6786-5453\")),\n             person(\"Thierry\", \"Onkelinx\", role=\"ctb\", comment = c(ORCID = \"0000-0001-8804-4216\")),\n             person(\"Michel\", \"Lang\", role=\"ctb\", comment = c(ORCID = \"0000-0001-9754-0393\")),\n             person(\"Viliam\", \"Simko\", role=\"ctb\"),\n             person(\"Kurt\", \"Hornik\", role=\"ctb\", comment = c(ORCID = \"0000-0003-4198-9911\")),\n             person(\"Radford\", \"Neal\", role=\"ctb\", comment = c(ORCID = \"0000-0002-2473-3407\")),\n             person(\"Kendon\", \"Bell\", role=\"ctb\", comment = c(ORCID = \"0000-0002-9093-8312\")),\n             person(\"Matthew\", \"de Queljoe\", role=\"ctb\"),\n             person(\"Dmitry\", \"Selivanov\", role=\"ctb\", comment = c(ORCID = \"0000-0003-0492-6647\")),\n             person(\"Ion\", \"Suruceanu\", role=\"ctb\", comment = c(ORCID = \"0009-0005-6446-4909\")),\n             person(\"Bill\", \"Denney\", role=\"ctb\", comment = c(ORCID = \"0000-0002-5759-428X\")),\n             person(\"Dirk\", \"Schumacher\", role=\"ctb\"),\n             person(\"András\", \"Svraka\", role=\"ctb\", comment = c(ORCID = \"0009-0008-8480-1329\")),\n             person(\"Sergey\", \"Fedorov\", role=\"ctb\", comment = c(ORCID = \"0000-0002-5970-7233\")),\n             person(\"Will\", \"Landau\", role=\"ctb\", comment = c(ORCID = \"0000-0003-1878-3253\")),\n             person(\"Floris\", \"Vanderhaeghe\", role=\"ctb\", comment = c(ORCID = \"0000-0002-6378-6229\")),\n             person(\"Kevin\", \"Tappe\", role=\"ctb\"),\n             person(\"Harris\", \"McGehee\", role=\"ctb\"),\n             person(\"Tim\", \"Mastny\", role=\"ctb\"),\n             person(\"Aaron\", \"Peikert\", role=\"ctb\", comment = c(ORCID = \"0000-0001-7813-818X\")),\n             person(\"Mark\", \"van der Loo\", role=\"ctb\", comment = c(ORCID = \"0000-0002-9807-4686\")),\n             person(\"Chris\", \"Muir\", role=\"ctb\", comment = c(ORCID = \"0000-0003-2555-3878\")),\n             person(\"Moritz\", \"Beller\", role=\"ctb\", comment = c(ORCID = \"0000-0003-4852-0526\")),\n             person(\"Sebastian\", \"Campbell\", role=\"ctb\", comment = c(ORCID = \"0009-0000-5948-4503\")),\n             person(\"Winston\", \"Chang\", role=\"ctb\", comment = c(ORCID = \"0000-0002-1576-2126\")),\n             person(\"Dean\", \"Attali\", role=\"ctb\", comment = c(ORCID = \"0000-0002-5645-3493\")),\n             person(\"Michael\", \"Chirico\", role=\"ctb\", comment = c(ORCID = \"0000-0003-0787-087X\")),\n             person(\"Kevin\", \"Ushey\", role=\"ctb\", comment = c(ORCID = \"0000-0003-2880-7407\")),\n             person(\"Carl\", \"Pearson\", role=\"ctb\", comment = c(ORCID = \"0000-0003-0701-7860\")))",
@@ -967,15 +1009,22 @@
         "Packaged": "2025-11-19 11:55:09 UTC; edd",
         "Author": "Dirk Eddelbuettel [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-6419-907X>),\n  Antoine Lucas [ctb] (ORCID: <https://orcid.org/0000-0002-8059-9767>),\n  Jarek Tuszynski [ctb],\n  Henrik Bengtsson [ctb] (ORCID: <https://orcid.org/0000-0002-7579-5165>),\n  Simon Urbanek [ctb] (ORCID: <https://orcid.org/0000-0003-2297-1732>),\n  Mario Frasca [ctb],\n  Bryan Lewis [ctb],\n  Murray Stokely [ctb],\n  Hannes Muehleisen [ctb] (ORCID:\n    <https://orcid.org/0000-0001-8552-0029>),\n  Duncan Murdoch [ctb],\n  Jim Hester [ctb] (ORCID: <https://orcid.org/0000-0002-2739-7082>),\n  Wush Wu [ctb] (ORCID: <https://orcid.org/0000-0001-5180-0567>),\n  Qiang Kou [ctb] (ORCID: <https://orcid.org/0000-0001-6786-5453>),\n  Thierry Onkelinx [ctb] (ORCID: <https://orcid.org/0000-0001-8804-4216>),\n  Michel Lang [ctb] (ORCID: <https://orcid.org/0000-0001-9754-0393>),\n  Viliam Simko [ctb],\n  Kurt Hornik [ctb] (ORCID: <https://orcid.org/0000-0003-4198-9911>),\n  Radford Neal [ctb] (ORCID: <https://orcid.org/0000-0002-2473-3407>),\n  Kendon Bell [ctb] (ORCID: <https://orcid.org/0000-0002-9093-8312>),\n  Matthew de Queljoe [ctb],\n  Dmitry Selivanov [ctb] (ORCID: <https://orcid.org/0000-0003-0492-6647>),\n  Ion Suruceanu [ctb] (ORCID: <https://orcid.org/0009-0005-6446-4909>),\n  Bill Denney [ctb] (ORCID: <https://orcid.org/0000-0002-5759-428X>),\n  Dirk Schumacher [ctb],\n  András Svraka [ctb] (ORCID: <https://orcid.org/0009-0008-8480-1329>),\n  Sergey Fedorov [ctb] (ORCID: <https://orcid.org/0000-0002-5970-7233>),\n  Will Landau [ctb] (ORCID: <https://orcid.org/0000-0003-1878-3253>),\n  Floris Vanderhaeghe [ctb] (ORCID:\n    <https://orcid.org/0000-0002-6378-6229>),\n  Kevin Tappe [ctb],\n  Harris McGehee [ctb],\n  Tim Mastny [ctb],\n  Aaron Peikert [ctb] (ORCID: <https://orcid.org/0000-0001-7813-818X>),\n  Mark van der Loo [ctb] (ORCID: <https://orcid.org/0000-0002-9807-4686>),\n  Chris Muir [ctb] (ORCID: <https://orcid.org/0000-0003-2555-3878>),\n  Moritz Beller [ctb] (ORCID: <https://orcid.org/0000-0003-4852-0526>),\n  Sebastian Campbell [ctb] (ORCID:\n    <https://orcid.org/0009-0000-5948-4503>),\n  Winston Chang [ctb] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Dean Attali [ctb] (ORCID: <https://orcid.org/0000-0002-5645-3493>),\n  Michael Chirico [ctb] (ORCID: <https://orcid.org/0000-0003-0787-087X>),\n  Kevin Ushey [ctb] (ORCID: <https://orcid.org/0000-0003-2880-7407>),\n  Carl Pearson [ctb] (ORCID: <https://orcid.org/0000-0003-0701-7860>)",
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-11-19 13:20:08 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:58 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2025-12-30 01:27:25 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "digest",
+        "RemotePkgRef": "digest",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.6.39"
       }
     },
     "dplyr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "dplyr",
@@ -1000,15 +1049,15 @@
         "Packaged": "2026-04-02 19:51:05 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4757-117X>),\n  Romain François [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>),\n  Lionel Henry [aut],\n  Kirill Müller [aut] (ORCID: <https://orcid.org/0000-0002-1416-3412>),\n  Davis Vaughan [aut] (ORCID: <https://orcid.org/0000-0003-4777-038X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-03 07:30:08 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:28:57 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-04-11 23:57:03 UTC; windows",
+        "Archs": "x64"
       }
     },
     "evaluate": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "evaluate",
@@ -1029,14 +1078,14 @@
         "Packaged": "2025-08-27 16:20:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Yihui Xie [aut] (ORCID: <https://orcid.org/0000-0003-0645-5666>),\n  Michael Lawrence [ctb],\n  Thomas Kluyver [ctb],\n  Jeroen Ooms [ctb],\n  Barret Schloerke [ctb],\n  Adam Ryczkowski [ctb],\n  Hiroaki Yutani [ctb],\n  Michel Lang [ctb],\n  Karolis Koncevičius [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-08-27 16:40:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:25:52 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:40 UTC; windows"
       }
     },
     "farver": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "farver",
@@ -1055,15 +1104,15 @@
         "Packaged": "2024-05-13 08:31:27 UTC; thomas",
         "Author": "Thomas Lin Pedersen [cre, aut]\n    (<https://orcid.org/0000-0002-5147-4711>),\n  Berendea Nicolae [aut] (Author of the ColorSpace C++ library),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-05-13 09:33:09 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:54 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:03:21 UTC; windows",
+        "Archs": "x64"
       }
     },
     "fastmap": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "fastmap",
         "Title": "Fast Data Structures",
@@ -1080,15 +1129,15 @@
         "Packaged": "2024-05-14 17:54:13 UTC; winston",
         "Author": "Winston Chang [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  Tessil [cph] (hopscotch_map library)",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-05-15 09:00:07 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:54 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:03:22 UTC; windows",
+        "Archs": "x64"
       }
     },
     "fontawesome": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "fontawesome",
@@ -1110,14 +1159,14 @@
         "Packaged": "2024-11-16 17:06:16 UTC; riannone",
         "Author": "Richard Iannone [aut, cre] (<https://orcid.org/0000-0003-3925-190X>),\n  Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>),\n  Winston Chang [ctb],\n  Dave Gandy [ctb, cph] (Font-Awesome font),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Richard Iannone <rich@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-11-16 17:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:12 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:21 UTC; windows"
       }
     },
     "forcats": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "forcats",
         "Title": "Tools for Working with Categorical Variables (Factors)",
@@ -1140,14 +1189,20 @@
         "Packaged": "2025-09-24 17:08:21 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-09-25 05:10:20 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:57 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-28 20:46:27 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "forcats",
+        "RemoteRef": "forcats",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
+        "RemoteSha": "1.0.1"
       }
     },
     "fresh": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "fresh",
         "Title": "Create Custom 'Bootstrap' Themes to Use in 'Shiny'",
@@ -1166,20 +1221,20 @@
         "Packaged": "2025-09-04 12:32:06 UTC; perri",
         "Author": "Victor Perrier [aut, cre, cph],\n  Fanny Meyer [aut],\n  Thomas Park [ctb, cph] (Bootswatch themes),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  onkbear [ctb, cph] (admin-lte-2-sass),\n  Colorlib [ctb, cph] (AdminLTE)",
         "Maintainer": "Victor Perrier <victor.perrier@dreamrs.fr>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-09-04 13:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-05-09 05:24:35 UTC; unix",
+        "Built": "R 4.5.3; ; 2026-05-16 18:50:25 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "fresh",
         "RemoteRef": "fresh",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
         "RemoteSha": "0.2.2"
       }
     },
     "fs": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "fs",
         "Title": "Cross-Platform File System Operations Based on 'libuv'",
@@ -1205,15 +1260,21 @@
         "Packaged": "2026-04-18 13:56:26 UTC; jeroen",
         "Author": "Jim Hester [aut],\n  Hadley Wickham [aut],\n  Gábor Csárdi [aut],\n  Jeroen Ooms [cre],\n  libuv project contributors [cph] (libuv library),\n  Joyent, Inc. and other Node contributors [cph] (libuv library),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-18 15:10:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:41 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:52:57 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "fs",
+        "RemoteRef": "fs",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.1.0"
       }
     },
     "generics": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "generics",
         "Title": "Common S3 Generics not Provided by Base R Methods Related to\nModel Fitting",
@@ -1234,14 +1295,14 @@
         "Packaged": "2025-05-09 18:17:41 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4757-117X>),\n  Max Kuhn [aut],\n  Davis Vaughan [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-05-09 23:50:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:25:55 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:20 UTC; windows"
       }
     },
     "ggbeeswarm": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "ggbeeswarm",
         "Type": "Package",
@@ -1262,14 +1323,14 @@
         "Packaged": "2025-11-29 00:53:34 UTC; erik",
         "Author": "Erik Clarke [aut, cre],\n  Scott Sherrill-Mix [aut],\n  Charlotte Dawson [aut]",
         "Maintainer": "Erik Clarke <erikclarke@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-11-29 06:10:25 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 16:19:47 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:58:00 UTC; windows"
       }
     },
     "ggplot2": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "ggplot2",
         "Title": "Create Elegant Data Visualisations Using the Grammar of Graphics",
@@ -1295,14 +1356,20 @@
         "Packaged": "2026-04-21 12:47:29 UTC; thomas",
         "Author": "Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>),\n  Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Lionel Henry [aut],\n  Thomas Lin Pedersen [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-5147-4711>),\n  Kohske Takahashi [aut],\n  Claus Wilke [aut] (ORCID: <https://orcid.org/0000-0002-7470-9261>),\n  Kara Woo [aut] (ORCID: <https://orcid.org/0000-0002-5125-4188>),\n  Hiroaki Yutani [aut] (ORCID: <https://orcid.org/0000-0002-3385-7233>),\n  Dewey Dunnington [aut] (ORCID: <https://orcid.org/0000-0002-9415-4582>),\n  Teun van den Brand [aut] (ORCID:\n    <https://orcid.org/0000-0002-9335-7468>),\n  Posit, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-22 09:10:03 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:16 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-05-04 17:39:03 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "ggplot2",
+        "RemoteRef": "ggplot2",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
+        "RemoteSha": "4.0.3"
       }
     },
     "glue": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "glue",
         "Title": "Interpreted String Literals",
@@ -1326,15 +1393,21 @@
         "Packaged": "2026-04-16 22:53:02 UTC; jenny",
         "Author": "Jim Hester [aut] (ORCID: <https://orcid.org/0000-0002-2739-7082>),\n  Jennifer Bryan [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-6983-2759>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-17 05:11:01 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:48 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:52:55 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "glue",
+        "RemoteRef": "glue",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.8.1"
       }
     },
     "golem": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "golem",
         "Title": "A Framework for Robust Shiny Applications",
@@ -1357,14 +1430,14 @@
         "Packaged": "2024-08-27 10:11:51 UTC; colinfay",
         "Author": "Colin Fay [cre, aut] (<https://orcid.org/0000-0001-7343-1846>),\n  Vincent Guyader [aut] (<https://orcid.org/0000-0003-0671-9270>,\n    previous maintainer),\n  Sébastien Rochette [aut] (<https://orcid.org/0000-0002-1565-9313>),\n  Cervan Girard [aut] (<https://orcid.org/0000-0002-4816-4624>),\n  Novica Nakov [ctb],\n  David Granjon [ctb],\n  Arthur Bréant [ctb],\n  Antoine Languillaume [ctb],\n  Ilya Zarubin [ctb],\n  ThinkR [cph]",
         "Maintainer": "Colin Fay <contact@colinfay.me>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-08-27 10:50:32 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:38:06 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-04-14 03:31:32 UTC; windows"
       }
     },
     "gt": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "gt",
@@ -1390,14 +1463,14 @@
         "Packaged": "2026-01-22 04:12:44 UTC; riannone",
         "Author": "Richard Iannone [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-3925-190X>),\n  Joe Cheng [aut],\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Shannon Haughton [aut],\n  Ellis Hughes [aut] (ORCID: <https://orcid.org/0000-0003-0637-4436>),\n  Alexandra Lauer [aut] (ORCID: <https://orcid.org/0000-0002-4191-6301>),\n  Romain François [aut],\n  JooYoung Seo [aut] (ORCID: <https://orcid.org/0000-0002-4064-6012>),\n  Ken Brevoort [aut] (ORCID: <https://orcid.org/0000-0002-4001-8358>),\n  Olivier Roy [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Richard Iannone <rich@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-22 06:10:50 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 16:40:02 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 04:35:55 UTC; windows"
       }
     },
     "gtable": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "gtable",
         "Title": "Arrange 'Grobs' in Tables",
@@ -1420,14 +1493,14 @@
         "Packaged": "2024-10-25 12:42:05 UTC; thomas",
         "Author": "Hadley Wickham [aut],\n  Thomas Lin Pedersen [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-10-25 13:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:17 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:15 UTC; windows"
       }
     },
     "here": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "here",
         "Title": "A Simpler Way to Find Your Files",
@@ -1449,14 +1522,14 @@
         "Packaged": "2025-09-14 18:48:53 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Jennifer Bryan [ctb] (ORCID: <https://orcid.org/0000-0002-6983-2759>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-09-15 05:10:09 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:55 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-04-14 02:19:58 UTC; windows"
       }
     },
     "highr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "highr",
         "Type": "Package",
@@ -1477,14 +1550,14 @@
         "Packaged": "2026-03-05 19:48:41 UTC; yihui",
         "Author": "Yihui Xie [aut, cre] (ORCID: <https://orcid.org/0000-0003-0645-5666>),\n  Yixuan Qiu [aut],\n  Christopher Gandrud [ctb],\n  Qiang Li [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-03-06 06:30:47 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:47 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:40 UTC; windows"
       }
     },
     "htmltools": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "htmltools",
@@ -1508,15 +1581,15 @@
         "Packaged": "2025-12-02 23:32:55 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Yihui Xie [aut],\n  Jeff Allen [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-04 11:50:09 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:50 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:59:45 UTC; windows",
+        "Archs": "x64"
       }
     },
     "htmlwidgets": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "htmlwidgets",
@@ -1537,14 +1610,14 @@
         "Packaged": "2023-12-06 00:11:16 UTC; cpsievert",
         "Author": "Ramnath Vaidyanathan [aut, cph],\n  Yihui Xie [aut],\n  JJ Allaire [aut],\n  Joe Cheng [aut],\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Kenton Russell [aut, cph],\n  Ellis Hughes [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-12-06 06:00:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:38:41 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 04:14:03 UTC; windows"
       }
     },
     "httpuv": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "httpuv",
@@ -1570,15 +1643,15 @@
         "Packaged": "2026-03-17 17:55:04 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Winston Chang [aut, cre],\n  Posit, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Hector Corrada Bravo [ctb],\n  Jeroen Ooms [ctb],\n  Andrzej Krzemienski [cph] (optional.hpp),\n  libuv project contributors [cph] (libuv library, see src/libuv/AUTHORS\n    file),\n  Joyent, Inc. and other Node contributors [cph] (libuv library, see\n    src/libuv/AUTHORS file; and http-parser library, see\n    src/http-parser/AUTHORS file),\n  Niels Provos [cph] (libuv subcomponent: tree.h),\n  Internet Systems Consortium, Inc. [cph] (libuv subcomponent: inet_pton\n    and inet_ntop, contained in src/libuv/src/inet.c),\n  Alexander Chemeris [cph] (libuv subcomponent: stdint-msvc2008.h (from\n    msinttypes)),\n  Google, Inc. [cph] (libuv subcomponent: pthread-fixes.c),\n  Sony Mobile Communcations AB [cph] (libuv subcomponent:\n    pthread-fixes.c),\n  Berkeley Software Design Inc. [cph] (libuv subcomponent:\n    android-ifaddrs.h, android-ifaddrs.c),\n  Kenneth MacKay [cph] (libuv subcomponent: android-ifaddrs.h,\n    android-ifaddrs.c),\n  Emergya (Cloud4all, FP7/2007-2013, grant agreement no 289016) [cph]\n    (libuv subcomponent: android-ifaddrs.h, android-ifaddrs.c),\n  Steve Reid [aut] (SHA-1 implementation),\n  James Brown [aut] (SHA-1 implementation),\n  Bob Trower [aut] (base64 implementation),\n  Alexander Peslyak [aut] (MD5 implementation),\n  Trantor Standard Systems [cph] (base64 implementation),\n  Igor Sysoev [cph] (http-parser)",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-03-18 06:12:59 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 16:00:57 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 00:51:35 UTC; windows",
+        "Archs": "x64"
       }
     },
     "httr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "httr",
         "Title": "Tools for Working with URLs and HTTP",
@@ -1599,14 +1672,14 @@
         "Packaged": "2026-02-13 13:25:45 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-02-13 16:20:15 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:29 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:39:06 UTC; windows"
       }
     },
     "httr2": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "httr2",
         "Title": "Perform HTTP Requests and Process the Responses",
@@ -1630,14 +1703,14 @@
         "Packaged": "2025-12-05 17:46:06 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  Maximilian Girlich [ctb]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-08 09:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:29:25 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:39:05 UTC; windows"
       }
     },
     "isoband": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "isoband",
         "Title": "Generate Isolines and Isobands from Regularly Spaced Elevation\nGrids",
@@ -1661,15 +1734,15 @@
         "Packaged": "2025-12-05 12:52:07 UTC; thomas",
         "Author": "Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>),\n  Claus O. Wilke [aut] (Original author, ORCID:\n    <https://orcid.org/0000-0002-7470-9261>),\n  Thomas Lin Pedersen [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-5147-4711>),\n  Posit, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-07 06:10:07 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:27:02 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:59:44 UTC; windows",
+        "Archs": "x64"
       }
     },
     "jose": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "jose",
         "Type": "Package",
@@ -1691,14 +1764,20 @@
         "Packaged": "2026-04-21 21:15:42 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-22 06:40:03 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:09 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-05-04 17:22:11 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "jose",
+        "RemoteRef": "jose",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
+        "RemoteSha": "2.0.0"
       }
     },
     "jquerylib": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "jquerylib",
         "Title": "Obtain 'jQuery' as an HTML Dependency Object",
@@ -1715,14 +1794,14 @@
         "Packaged": "2021-04-26 16:40:21 UTC; cpsievert",
         "Author": "Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  RStudio [cph],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/lib/jquery-AUTHORS.txt)",
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2021-04-26 17:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:12 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:20 UTC; windows"
       }
     },
     "jsonlite": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "jsonlite",
         "Version": "2.0.0",
@@ -1741,15 +1820,15 @@
         "NeedsCompilation": "yes",
         "Packaged": "2025-03-26 11:36:10 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Duncan Temple Lang [ctb],\n  Lloyd Hilaiel [cph] (author of bundled libyajl)",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-27 06:40:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:58 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-08-04 00:19:44 UTC; windows",
+        "Archs": "x64"
       }
     },
     "juicyjuice": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "juicyjuice",
         "Title": "Inline CSS Properties into HTML Tags Using 'juice'",
@@ -1768,14 +1847,14 @@
         "Packaged": "2022-11-09 19:42:30 UTC; rich",
         "Author": "Richard Iannone [aut, cre, cph]\n    (<https://orcid.org/0000-0003-3925-190X>),\n  Automattic [cph] (juice library),\n  juice contributors [ctb] (juice library)",
         "Maintainer": "Richard Iannone <riannone@me.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2022-11-10 19:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:49:36 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:00:10 UTC; windows"
       }
     },
     "knitr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "knitr",
         "Type": "Package",
@@ -1798,14 +1877,21 @@
         "Packaged": "2025-12-19 15:19:25 UTC; yihui",
         "Author": "Yihui Xie [aut, cre] (ORCID: <https://orcid.org/0000-0003-0645-5666>,\n    URL: https://yihui.org),\n  Abhraneel Sarma [ctb],\n  Adam Vogt [ctb],\n  Alastair Andrew [ctb],\n  Alex Zvoleff [ctb],\n  Amar Al-Zubaidi [ctb],\n  Andre Simon [ctb] (the CSS files under inst/themes/ were derived from\n    the Highlight package http://www.andre-simon.de),\n  Aron Atkins [ctb],\n  Aaron Wolen [ctb],\n  Ashley Manton [ctb],\n  Atsushi Yasumoto [ctb] (ORCID: <https://orcid.org/0000-0002-8335-495X>),\n  Ben Baumer [ctb],\n  Brian Diggs [ctb],\n  Brian Zhang [ctb],\n  Bulat Yapparov [ctb],\n  Cassio Pereira [ctb],\n  Christophe Dervieux [ctb],\n  David Hall [ctb],\n  David Hugh-Jones [ctb],\n  David Robinson [ctb],\n  Doug Hemken [ctb],\n  Duncan Murdoch [ctb],\n  Elio Campitelli [ctb],\n  Ellis Hughes [ctb],\n  Emily Riederer [ctb],\n  Fabian Hirschmann [ctb],\n  Fitch Simeon [ctb],\n  Forest Fang [ctb],\n  Frank E Harrell Jr [ctb] (the Sweavel package at inst/misc/Sweavel.sty),\n  Garrick Aden-Buie [ctb],\n  Gregoire Detrez [ctb],\n  Hadley Wickham [ctb],\n  Hao Zhu [ctb],\n  Heewon Jeon [ctb],\n  Henrik Bengtsson [ctb],\n  Hiroaki Yutani [ctb],\n  Ian Lyttle [ctb],\n  Hodges Daniel [ctb],\n  Jacob Bien [ctb],\n  Jake Burkhead [ctb],\n  James Manton [ctb],\n  Jared Lander [ctb],\n  Jason Punyon [ctb],\n  Javier Luraschi [ctb],\n  Jeff Arnold [ctb],\n  Jenny Bryan [ctb],\n  Jeremy Ashkenas [ctb, cph] (the CSS file at\n    inst/misc/docco-classic.css),\n  Jeremy Stephens [ctb],\n  Jim Hester [ctb],\n  Joe Cheng [ctb],\n  Johannes Ranke [ctb],\n  John Honaker [ctb],\n  John Muschelli [ctb],\n  Jonathan Keane [ctb],\n  JJ Allaire [ctb],\n  Johan Toloe [ctb],\n  Jonathan Sidi [ctb],\n  Joseph Larmarange [ctb],\n  Julien Barnier [ctb],\n  Kaiyin Zhong [ctb],\n  Kamil Slowikowski [ctb],\n  Karl Forner [ctb],\n  Kevin K. Smith [ctb],\n  Kirill Mueller [ctb],\n  Kohske Takahashi [ctb],\n  Lorenz Walthert [ctb],\n  Lucas Gallindo [ctb],\n  Marius Hofert [ctb],\n  Martin Modrák [ctb],\n  Michael Chirico [ctb],\n  Michael Friendly [ctb],\n  Michal Bojanowski [ctb],\n  Michel Kuhlmann [ctb],\n  Miller Patrick [ctb],\n  Nacho Caballero [ctb],\n  Nick Salkowski [ctb],\n  Niels Richard Hansen [ctb],\n  Noam Ross [ctb],\n  Obada Mahdi [ctb],\n  Pavel N. Krivitsky [ctb] (ORCID:\n    <https://orcid.org/0000-0002-9101-3362>),\n  Pedro Faria [ctb],\n  Qiang Li [ctb],\n  Ramnath Vaidyanathan [ctb],\n  Richard Cotton [ctb],\n  Robert Krzyzanowski [ctb],\n  Rodrigo Copetti [ctb],\n  Romain Francois [ctb],\n  Ruaridh Williamson [ctb],\n  Sagiru Mati [ctb] (ORCID: <https://orcid.org/0000-0003-1413-3974>),\n  Scott Kostyshak [ctb],\n  Sebastian Meyer [ctb],\n  Sietse Brouwer [ctb],\n  Simon de Bernard [ctb],\n  Sylvain Rousseau [ctb],\n  Taiyun Wei [ctb],\n  Thibaut Assus [ctb],\n  Thibaut Lamadon [ctb],\n  Thomas Leeper [ctb],\n  Tim Mastny [ctb],\n  Tom Torsney-Weir [ctb],\n  Trevor Davis [ctb],\n  Viktoras Veitas [ctb],\n  Weicheng Zhu [ctb],\n  Wush Wu [ctb],\n  Zachary Foster [ctb],\n  Zhian N. Kamvar [ctb] (ORCID: <https://orcid.org/0000-0003-1458-7108>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-20 14:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:57 UTC; unix"
+        "Built": "R 4.5.2; ; 2025-12-30 02:28:12 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "knitr",
+        "RemotePkgRef": "knitr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.51"
       }
     },
     "labeling": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "labeling",
         "Type": "Package",
@@ -1820,15 +1906,14 @@
         "NeedsCompilation": "no",
         "Imports": "stats, graphics",
         "Packaged": "2023-08-29 21:01:57 UTC; loki",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-08-29 22:20:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-24 05:25:54 UTC; unix"
+        "Built": "R 4.5.2; ; 2025-11-01 00:30:56 UTC; windows"
       }
     },
     "later": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "later",
@@ -1854,15 +1939,15 @@
         "Packaged": "2026-03-03 21:55:53 UTC; cg334",
         "Author": "Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Joe Cheng [aut],\n  Charlie Gao [aut, cre] (ORCID: <https://orcid.org/0000-0002-0750-061X>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Marcus Geelnard [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/),\n  Evan Nemerson [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/)",
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-03-05 07:50:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 15:56:05 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:59:43 UTC; windows",
+        "Archs": "x64"
       }
     },
     "lazyeval": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "lazyeval",
         "Version": "0.2.3",
@@ -1880,22 +1965,15 @@
         "Packaged": "2026-04-03 09:37:04 UTC; lionel",
         "Author": "Hadley Wickham [aut, cre],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-04 05:10:53 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-05-09 04:53:16 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17",
-        "RemoteType": "standard",
-        "RemotePkgRef": "lazyeval",
-        "RemoteRef": "lazyeval",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "0.2.3"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-04-14 02:19:54 UTC; windows",
+        "Archs": "x64"
       }
     },
     "lifecycle": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "lifecycle",
         "Title": "Manage the Life Cycle of your Package Functions",
@@ -1917,14 +1995,14 @@
         "Packaged": "2026-01-07 15:00:49 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-08 08:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:00 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:59:45 UTC; windows"
       }
     },
     "litedown": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "litedown",
         "Type": "Package",
@@ -1945,14 +2023,14 @@
         "Packaged": "2025-12-18 16:42:41 UTC; yihui",
         "Author": "Yihui Xie [aut, cre] (ORCID: <https://orcid.org/0000-0003-0645-5666>,\n    URL: https://yihui.org),\n  Tim Taylor [ctb] (ORCID: <https://orcid.org/0000-0002-8587-7113>)",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-18 17:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:49 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:04:46 UTC; windows"
       }
     },
     "lubridate": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "lubridate",
@@ -1979,15 +2057,21 @@
         "NeedsCompilation": "yes",
         "Packaged": "2026-02-03 09:30:08 UTC; vitalie",
         "Author": "Vitalie Spinu [aut, cre],\n  Garrett Grolemund [aut],\n  Hadley Wickham [aut],\n  Davis Vaughan [ctb],\n  Ian Lyttle [ctb],\n  Imanuel Costigan [ctb],\n  Jason Law [ctb],\n  Doug Mitarotonda [ctb],\n  Joseph Larmarange [ctb],\n  Jonathan Boiser [ctb],\n  Chel Hee Lee [ctb]",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-02-04 09:00:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:27:15 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-28 19:56:30 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "lubridate",
+        "RemoteRef": "lubridate",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.9.5"
       }
     },
     "magrittr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "magrittr",
@@ -2009,15 +2093,21 @@
         "Packaged": "2026-04-03 08:09:48 UTC; lionel",
         "Author": "Stefan Milton Bache [aut, cph] (Original author and creator of\n    magrittr),\n  Hadley Wickham [aut],\n  Lionel Henry [cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-04 08:00:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:25:55 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:52:55 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "magrittr",
+        "RemoteRef": "magrittr",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.0.5"
       }
     },
     "markdown": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "markdown",
         "Type": "Package",
@@ -2037,14 +2127,14 @@
         "Packaged": "2025-03-23 17:06:26 UTC; runner",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  JJ Allaire [aut],\n  Jeffrey Horner [aut],\n  Henrik Bengtsson [ctb],\n  Jim Hester [ctb],\n  Yixuan Qiu [ctb],\n  Kohske Takahashi [ctb],\n  Adam November [ctb],\n  Nacho Caballero [ctb],\n  Jeroen Ooms [ctb],\n  Thomas Leeper [ctb],\n  Joe Cheng [ctb],\n  Andrzej Oles [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-23 19:30:03 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:07 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:00:09 UTC; windows"
       }
     },
     "memoise": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "memoise",
         "Title": "'Memoisation' of Functions",
@@ -2062,14 +2152,14 @@
         "Packaged": "2021-11-24 21:24:50 UTC; jhester",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Winston Chang [aut, cre],\n  Kirill Müller [aut],\n  Daniel Cook [aut],\n  Mark Edmondson [ctb]",
         "Maintainer": "Winston Chang <winston@rstudio.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2021-11-26 16:11:10 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:01 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:20 UTC; windows"
       }
     },
     "mime": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "mime",
         "Type": "Package",
@@ -2087,20 +2177,20 @@
         "Packaged": "2025-03-17 19:54:24 UTC; runner",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>,\n    https://yihui.org),\n  Jeffrey Horner [ctb],\n  Beilei Bian [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-17 20:20:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:02 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2025-11-01 00:30:57 UTC; windows",
+        "Archs": "x64"
       }
     },
     "openssl": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "openssl",
         "Type": "Package",
         "Title": "Toolkit for Encryption, Signatures and Certificates Based on\nOpenSSL",
-        "Version": "2.4.1",
+        "Version": "2.4.2",
         "Authors@R": "c(person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), email = \"jeroenooms@gmail.com\",\n    comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Oliver\", \"Keyes\", role = \"ctb\"))",
         "Description": "Bindings to OpenSSL libssl and libcrypto, plus custom SSH key parsers.\n    Supports RSA, DSA and EC curves P-256, P-384, P-521, and curve25519. Cryptographic\n    signatures can either be created and verified manually or via x509 certificates. \n    AES can be used in cbc, ctr or gcm mode for symmetric encryption; RSA for asymmetric\n    (public key) encryption or EC for Diffie Hellman. High-level envelope functions \n    combine RSA and AES for encrypting arbitrary sized data. Other utilities include key\n    generators, hash functions (md5, sha1, sha256, etc), base64 encoder, a secure random\n    number generator, and 'bignum' math methods for manually performing crypto \n    calculations on large multibyte integers.",
         "License": "MIT + file LICENSE",
@@ -2110,21 +2200,27 @@
         "VignetteBuilder": "knitr",
         "Imports": "askpass",
         "Suggests": "curl, testthat (>= 2.1.0), digest, knitr, rmarkdown,\njsonlite, jose, sodium",
-        "RoxygenNote": "7.3.2",
         "Encoding": "UTF-8",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-05-14 13:48:16 UTC; jeroen",
+        "Packaged": "2026-06-09 10:51:42 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  Oliver Keyes [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
-        "Date/Publication": "2026-05-14 14:50:14 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-05-15 06:17:34 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Repository": "CRAN",
+        "Date/Publication": "2026-06-09 13:30:02 UTC",
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-06-09 23:51:21 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "openssl",
+        "RemoteRef": "openssl",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.4.2"
       }
     },
     "otel": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "otel",
         "Title": "OpenTelemetry R API",
@@ -2145,14 +2241,14 @@
         "Packaged": "2025-08-29 12:46:28 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-08-29 13:30:07 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:14 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:21 UTC; windows"
       }
     },
     "pillar": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "pillar",
         "Title": "Coloured Formatting for Columns",
@@ -2178,14 +2274,14 @@
         "Packaged": "2025-09-17 03:59:12 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  RStudio [cph]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-09-17 11:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:03 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:19 UTC; windows"
       }
     },
     "pkgbuild": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "pkgbuild",
         "Title": "Find Tools Needed to Build R Packages",
@@ -2207,14 +2303,14 @@
         "Packaged": "2025-05-26 10:36:48 UTC; gaborcsardi",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Gábor Csárdi [aut, cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-05-26 14:10:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:37 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:39:06 UTC; windows"
       }
     },
     "pkgconfig": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "pkgconfig",
         "Title": "Private Configuration for 'R' Packages",
@@ -2231,14 +2327,14 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
         "Packaged": "2019-09-22 08:42:40 UTC; gaborcsardi",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2019-09-22 09:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:12 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:21 UTC; windows"
       }
     },
     "pkgload": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "pkgload",
         "Title": "Simulate Package Installation and Attach",
@@ -2261,14 +2357,20 @@
         "Packaged": "2026-04-21 17:18:59 UTC; lionel",
         "Author": "Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Core team [ctb] (Some namespace and vignette code extracted from base\n    R)",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-22 06:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:34 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-05-04 18:03:23 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "pkgload",
+        "RemoteRef": "pkgload",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
+        "RemoteSha": "1.5.2"
       }
     },
     "plotly": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "plotly",
         "Title": "Create Interactive Web Graphics via 'plotly.js'",
@@ -2289,20 +2391,14 @@
         "Packaged": "2026-01-24 00:53:27 UTC; cpsievert",
         "Author": "Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Chris Parmer [aut],\n  Toby Hocking [aut],\n  Scott Chamberlain [aut],\n  Karthik Ram [aut],\n  Marianne Corvellec [aut] (ORCID:\n    <https://orcid.org/0000-0002-1994-3581>),\n  Pedro Despouy [aut],\n  Salim Brüggemann [ctb] (ORCID: <https://orcid.org/0000-0002-5329-5987>),\n  Plotly Technologies Inc. [cph]",
         "Maintainer": "Carson Sievert <cpsievert1@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-24 07:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-05-09 05:22:26 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "plotly",
-        "RemoteRef": "plotly",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "4.12.0"
+        "Built": "R 4.5.3; ; 2026-04-14 04:05:19 UTC; windows"
       }
     },
     "processx": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "processx",
         "Title": "Execute and Control System Processes",
@@ -2324,15 +2420,21 @@
         "Packaged": "2026-04-22 10:56:15 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-22 12:00:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:37 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 16:42:18 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "processx",
+        "RemoteRef": "processx",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "3.9.0"
       }
     },
     "promises": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "promises",
@@ -2357,14 +2459,14 @@
         "Packaged": "2025-10-31 20:26:43 UTC; barret",
         "Author": "Joe Cheng [aut],\n  Barret Schloerke [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-9986-114X>),\n  Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Charlie Gao [aut] (ORCID: <https://orcid.org/0000-0002-0750-061X>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Barret Schloerke <barret@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-11-01 06:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:40 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:22 UTC; windows"
       }
     },
     "ps": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "ps",
         "Title": "List, Query, Manipulate System Processes",
@@ -2387,15 +2489,21 @@
         "Packaged": "2026-04-20 12:53:07 UTC; gaborcsardi",
         "Author": "Jay Loden [aut],\n  Dave Daeschler [aut],\n  Giampaolo Rodola' [aut],\n  Gábor Csárdi [aut, cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-20 13:40:03 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:16 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:53:12 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "ps",
+        "RemoteRef": "ps",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.9.3"
       }
     },
     "purrr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "purrr",
         "Title": "Functional Programming Tools",
@@ -2421,15 +2529,21 @@
         "Packaged": "2026-04-10 10:15:54 UTC; lionel",
         "Author": "Hadley Wickham [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4757-117X>),\n  Lionel Henry [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-10 17:00:09 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:28:02 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 17:39:00 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "purrr",
+        "RemoteRef": "purrr",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.2.2"
       }
     },
     "rappdirs": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "rappdirs",
@@ -2452,15 +2566,15 @@
         "Packaged": "2026-01-16 22:03:30 UTC; hadleywickham",
         "Author": "Hadley Wickham [trl, cre, cph],\n  Sridhar Ratnakumar [aut],\n  Trent Mick [aut],\n  ActiveState [cph] (R/appdir.r, R/cache.r, R/data.r, R/log.r translated\n    from appdirs),\n  Eddy Petrisor [ctb],\n  Trevor Davis [trl, aut] (ORCID:\n    <https://orcid.org/0000-0001-6341-4639>),\n  Gabor Csardi [ctb],\n  Gregory Jefferis [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-17 08:40:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:18 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:03:21 UTC; windows",
+        "Archs": "x64"
       }
     },
     "reactR": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "reactR",
         "Type": "Package",
@@ -2481,14 +2595,14 @@
         "NeedsCompilation": "no",
         "Packaged": "2024-09-14 13:24:57 UTC; kentr",
         "Author": "Facebook Inc [aut, cph] (React library in lib, https://reactjs.org/;\n    see AUTHORS for full list of contributors),\n  Michel Weststrate [aut, cph] (mobx library in lib,\n    https://github.com/mobxjs),\n  Kent Russell [aut, cre] (R interface),\n  Alan Dipert [aut] (R interface),\n  Greg Lin [aut] (R interface)",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-09-14 13:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:56:52 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:00:10 UTC; windows"
       }
     },
     "reactable": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "reactable",
         "Type": "Package",
@@ -2509,9 +2623,9 @@
         "Packaged": "2025-12-01 15:17:46 UTC; greg",
         "Author": "Greg Lin [aut, cre],\n  Tanner Linsley [ctb, cph] (React Table library),\n  Emotion team and other contributors [ctb, cph] (Emotion library),\n  Kent Russell [ctb, cph] (reactR package),\n  Ramnath Vaidyanathan [ctb, cph] (htmlwidgets package),\n  Joe Cheng [ctb, cph] (htmlwidgets package),\n  JJ Allaire [ctb, cph] (htmlwidgets package),\n  Yihui Xie [ctb, cph] (htmlwidgets package),\n  Kenton Russell [ctb, cph] (htmlwidgets package),\n  Facebook, Inc. and its affiliates [ctb, cph] (React library),\n  FormatJS [ctb, cph] (FormatJS libraries),\n  Feross Aboukhadijeh, and other contributors [ctb, cph] (buffer library),\n  Roman Shtylman [ctb, cph] (process library),\n  James Halliday [ctb, cph] (stream-browserify library),\n  Posit Software, PBC [fnd, cph]",
         "Maintainer": "Greg Lin <glin@glin.io>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-01 16:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 16:29:29 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 04:14:12 UTC; windows"
       }
     },
     "reskit": {
@@ -2520,7 +2634,7 @@
       "description": {
         "Package": "reskit",
         "Title": "Nice selection box of goodies for hobnobbing with NHP model\nresults",
-        "Version": "1.0.0",
+        "Version": "1.0.1",
         "Authors@R": "\n    c(person(\n        \"Fran\", \"Barton\",\n        email = \"francis.barton@nhs.net\",\n        role = c(\"aut\", \"cre\"),\n        comment = c(ORCID = \"0000-0002-5650-1176\")\n    ),\n    person(\n        \"Matt\", \"Dray\",\n        email = \"matt.dray@nhs.net\",\n        role = \"ctb\"\n    ),\n    person(\n        \"Rhian\", \"Davies\",\n        email = \"rhian.davies25@nhs.net\",\n        role = \"ctb\"\n    ))",
         "Description": "'Wafer' goodbye to crumbly code, and dunk a sturdy reskit\n    function in your data cuppa instead. We've clustered the cream of our\n    results code here - it's a cracker!",
         "License": "MIT + file LICENSE",
@@ -2528,7 +2642,7 @@
         "Roxygen": "list(markdown = TRUE)",
         "Config/testthat/edition": "3",
         "Depends": "R (>= 4.5.0)",
-        "Imports": "azkit (>= 0.3.0), AzureStor, base64enc, cli, dplyr, forcats,\nggbeeswarm, ggplot2, glue, gt, httr2, purrr, rlang, scales,\nsnakecase, tidyr, tidyselect, yaml12, yyjsonr",
+        "Imports": "azkit (>= 0.3.0), base64enc, dplyr, forcats, ggbeeswarm,\nggplot2, glue, gt, httr2, purrr, rlang, scales, snakecase,\ntidyr, tidyselect, yaml12, yyjsonr",
         "Remotes": "The-Strategy-Unit/azkit",
         "Suggests": "here, readr, testthat (>= 3.0.0), tibble, withr",
         "Config/roxygen2/version": "8.0.0",
@@ -2536,23 +2650,23 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "nhp_reskit",
         "RemoteUsername": "The-Strategy-Unit",
-        "RemotePkgRef": "reskit=github::The-Strategy-Unit/nhp_reskit",
+        "RemotePkgRef": "The-Strategy-Unit/nhp_reskit",
         "RemoteRef": "HEAD",
-        "RemoteSha": "effb6fe1f66ce11150fcbbdafa78ada71c03599a",
+        "RemoteSha": "6e923c2f36aca9b00b85ce1c6dfab9b82615e2a8",
         "GithubRepo": "nhp_reskit",
         "GithubUsername": "The-Strategy-Unit",
         "GithubRef": "HEAD",
-        "GithubSHA1": "effb6fe1f66ce11150fcbbdafa78ada71c03599a",
+        "GithubSHA1": "6e923c2f36aca9b00b85ce1c6dfab9b82615e2a8",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-18 20:56:08 UTC; tom",
+        "Packaged": "2026-06-16 15:33:02 UTC; Matt.Dray",
         "Author": "Fran Barton [aut, cre] (ORCID: <https://orcid.org/0000-0002-5650-1176>),\n  Matt Dray [ctb],\n  Rhian Davies [ctb]",
         "Maintainer": "Fran Barton <francis.barton@nhs.net>",
-        "Built": "R 4.6.0; ; 2026-05-18 20:56:09 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-06-16 15:33:04 UTC; windows"
       }
     },
     "rlang": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "rlang",
         "Version": "1.2.0",
@@ -2577,15 +2691,21 @@
         "Packaged": "2026-04-02 12:23:10 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  mikefc [cph] (Hash implementation based on Mike's xxhashlite),\n  Yann Collet [cph] (Author of the embedded xxHash library),\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-06 10:40:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:19 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:52:56 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "rlang",
+        "RemoteRef": "rlang",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.2.0"
       }
     },
     "rmarkdown": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "rmarkdown",
@@ -2611,12 +2731,19 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "RSPM",
         "Date/Publication": "2026-03-26 16:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:36:46 UTC; unix"
+        "Built": "R 4.5.0; ; 2026-03-27 04:53:54 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "rmarkdown",
+        "RemotePkgRef": "rmarkdown",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.31"
       }
     },
     "rprojroot": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "rprojroot",
         "Title": "Finding Files in Project Subdirectories",
@@ -2639,14 +2766,14 @@
         "Packaged": "2025-08-26 15:22:42 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-08-26 16:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:45 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:28 UTC; windows"
       }
     },
     "rstudioapi": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "rstudioapi",
         "Title": "Safely Access the RStudio API",
@@ -2664,14 +2791,14 @@
         "NeedsCompilation": "no",
         "Packaged": "2026-01-15 18:05:24 UTC; kevin",
         "Author": "Kevin Ushey [aut, cre],\n  JJ Allaire [aut],\n  Hadley Wickham [aut],\n  Gary Ritchie [aut],\n  RStudio [cph]",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-16 09:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:18 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:22 UTC; windows"
       }
     },
     "sass": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "sass",
@@ -2693,15 +2820,15 @@
         "Packaged": "2025-04-11 18:34:19 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Timothy Mastny [aut],\n  Richard Iannone [aut] (<https://orcid.org/0000-0003-3925-190X>),\n  Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>),\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>),\n  RStudio [cph, fnd],\n  Sass Open Source Foundation [ctb, cph] (LibSass library),\n  Greter Marcel [ctb, cph] (LibSass library),\n  Mifsud Michael [ctb, cph] (LibSass library),\n  Hampton Catlin [ctb, cph] (LibSass library),\n  Natalie Weizenbaum [ctb, cph] (LibSass library),\n  Chris Eppstein [ctb, cph] (LibSass library),\n  Adams Joseph [ctb, cph] (json.cpp),\n  Trifunovic Nemanja [ctb, cph] (utf8.h)",
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-04-11 19:50:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:29:08 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 03:19:21 UTC; windows",
+        "Archs": "x64"
       }
     },
     "scales": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "scales",
         "Title": "Scale Functions for Visualization",
@@ -2724,14 +2851,14 @@
         "Packaged": "2025-04-23 18:27:04 UTC; thomas",
         "Author": "Hadley Wickham [aut],\n  Thomas Lin Pedersen [cre, aut]\n    (<https://orcid.org/0000-0002-5147-4711>),\n  Dana Seidel [aut],\n  Posit Software, PBC [cph, fnd] (03wc8by49)",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-04-24 11:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:27:23 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:16 UTC; windows"
       }
     },
     "shiny": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "shiny",
@@ -2754,14 +2881,14 @@
         "Packaged": "2026-02-19 20:25:10 UTC; cpsievert",
         "Author": "Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Garrick Aden-Buie [aut] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  Yihui Xie [aut],\n  Jeff Allen [aut],\n  Jonathan McPherson [aut],\n  Alan Dipert [aut],\n  Barbara Borges [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/www/shared/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Prem Nawaz Khan [ctb] (Bootstrap accessibility plugin),\n  Victor Tsaran [ctb] (Bootstrap accessibility plugin),\n  Dennis Lembree [ctb] (Bootstrap accessibility plugin),\n  Srinivasu Chakravarthula [ctb] (Bootstrap accessibility plugin),\n  Cathy O'Connor [ctb] (Bootstrap accessibility plugin),\n  PayPal, Inc [cph] (Bootstrap accessibility plugin),\n  Stefan Petre [ctb, cph] (Bootstrap-datepicker library),\n  Andrew Rowls [ctb, cph] (Bootstrap-datepicker library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Salmen Bejaoui [ctb, cph] (selectize-plugin-a11y library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library),\n  SpryMedia Limited [ctb, cph] (DataTables library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  R Core Team [ctb, cph] (tar implementation from R)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-02-20 09:00:03 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:35:37 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:57:33 UTC; windows"
       }
     },
     "shinycssloaders": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "shinycssloaders",
         "Title": "Add Loading Animations to a 'shiny' Output While It's\nRecalculating",
@@ -2780,14 +2907,14 @@
         "Packaged": "2024-07-30 18:52:48 UTC; Dean",
         "Author": "Dean Attali [aut, cre] (Maintainer/developer of shinycssloaders since\n    2019, <https://orcid.org/0000-0002-5645-3493>),\n  Andras Sali [aut] (Original creator of shinycssloaders package),\n  Luke Hass [ctb, cph] (Author of included CSS loader code)",
         "Maintainer": "Dean Attali <daattali@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-07-30 22:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:39:03 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:58:18 UTC; windows"
       }
     },
     "shinyjs": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "shinyjs",
         "Title": "Easily Improve the User Experience of Your Shiny Apps in Seconds",
@@ -2807,20 +2934,14 @@
         "Packaged": "2026-01-14 23:37:28 UTC; Dean",
         "Author": "Dean Attali [aut, cre] (ORCID: <https://orcid.org/0000-0002-5645-3493>)",
         "Maintainer": "Dean Attali <daattali@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-15 06:10:08 UTC",
-        "Built": "R 4.6.0; ; 2026-05-09 05:24:43 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "shinyjs",
-        "RemoteRef": "shinyjs",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "2.1.1"
+        "Built": "R 4.5.3; ; 2026-04-14 03:31:25 UTC; windows"
       }
     },
     "snakecase": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "snakecase",
         "Version": "0.11.1",
@@ -2841,14 +2962,14 @@
         "NeedsCompilation": "no",
         "Packaged": "2023-08-27 20:30:20 UTC; malte",
         "Author": "Malte Grosser [aut, cre]",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-08-27 22:50:09 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 16:12:28 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-04-14 03:14:19 UTC; windows"
       }
     },
     "sourcetools": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "sourcetools",
         "Type": "Package",
@@ -2866,15 +2987,15 @@
         "NeedsCompilation": "yes",
         "Packaged": "2026-03-27 21:33:04 UTC; kevin",
         "Author": "Kevin Ushey [aut, cre]",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-03-28 06:10:35 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:46 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-04-14 01:27:58 UTC; windows",
+        "Archs": "x64"
       }
     },
     "stringi": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "stringi",
         "Version": "1.8.7",
@@ -2897,15 +3018,15 @@
         "Author": "Marek Gagolewski [aut, cre, cph]\n    (<https://orcid.org/0000-0003-0637-6028>),\n  Bartek Tartanus [ctb],\n  Unicode, Inc. and others [ctb] (ICU4C source code, Unicode Character\n    Database)",
         "Maintainer": "Marek Gagolewski <marek@gagolewski.com>",
         "License_is_FOSS": "yes",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-27 13:10:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:27:01 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_27"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2025-11-01 00:31:12 UTC; windows",
+        "Archs": "x64"
       }
     },
     "stringr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "stringr",
         "Title": "Simple, Consistent Wrappers for Common String Operations",
@@ -2929,14 +3050,14 @@
         "Packaged": "2025-11-03 22:09:58 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre, cph],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-11-04 14:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:33:34 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:19 UTC; windows"
       }
     },
     "sys": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "sys",
         "Type": "Package",
@@ -2955,15 +3076,15 @@
         "Packaged": "2024-10-03 14:13:17 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Gábor Csárdi [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-10-04 09:40:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:22 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:03:21 UTC; windows",
+        "Archs": "x64"
       }
     },
     "tibble": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "tibble",
         "Title": "Simple Data Frames",
@@ -2991,15 +3112,15 @@
         "Packaged": "2026-01-10 18:28:47 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-11 10:10:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:28:27 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 03:39:00 UTC; windows",
+        "Archs": "x64"
       }
     },
     "tidyr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "tidyr",
         "Title": "Tidy Messy Data",
@@ -3024,15 +3145,15 @@
         "Packaged": "2025-12-17 23:35:11 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Davis Vaughan [aut],\n  Maximilian Girlich [aut],\n  Kevin Ushey [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-19 09:20:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:34:31 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 04:14:03 UTC; windows",
+        "Archs": "x64"
       }
     },
     "tidyselect": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "tidyselect",
         "Title": "Select from a Set of Strings",
@@ -3055,14 +3176,14 @@
         "Packaged": "2024-03-11 11:46:04 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-03-11 14:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:28:03 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 03:19:19 UTC; windows"
       }
     },
     "timechange": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "timechange",
         "Title": "Efficient Manipulation of Date-Times",
@@ -3082,15 +3203,21 @@
         "Packaged": "2026-01-29 08:59:34 UTC; vitalie",
         "Author": "Vitalie Spinu [aut, cre],\n  Google Inc. [ctb, cph]",
         "Maintainer": "Vitalie Spinu <spinuvit@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-29 22:20:08 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:44 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_24"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-28 19:36:36 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "timechange",
+        "RemoteRef": "timechange",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.4.0"
       }
     },
     "tinytex": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "tinytex",
         "Type": "Package",
@@ -3109,14 +3236,14 @@
         "Packaged": "2026-03-27 22:21:20 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>),\n  Posit Software, PBC [cph, fnd],\n  Christophe Dervieux [ctb] (ORCID:\n    <https://orcid.org/0000-0003-4474-2498>),\n  Devon Ryan [ctb] (ORCID: <https://orcid.org/0000-0002-8549-0971>),\n  Ethan Heinzen [ctb],\n  Fernando Cagua [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-03-28 06:10:10 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:49 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-04-14 02:19:54 UTC; windows"
       }
     },
     "utf8": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "utf8",
         "Title": "Unicode Text Processing",
@@ -3136,15 +3263,15 @@
         "Packaged": "2025-06-08 18:28:11 UTC; kirill",
         "Author": "Patrick O. Perry [aut, cph],\n  Kirill Müller [cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>),\n  Unicode, Inc. [cph, dtc] (Unicode Character Database)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-06-08 19:00:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:25 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:03:20 UTC; windows",
+        "Archs": "x64"
       }
     },
     "uuid": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "uuid",
         "Version": "1.2-2",
@@ -3159,16 +3286,15 @@
         "BugReports": "https://github.com/s-u/uuid/issues",
         "NeedsCompilation": "yes",
         "Packaged": "2026-01-23 00:09:28 UTC; rforge",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-23 06:40:09 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:29 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_27"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-26 00:51:02 UTC; windows",
+        "Archs": "x64"
       }
     },
     "vctrs": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "vctrs",
         "Title": "Vector Helpers",
@@ -3194,15 +3320,21 @@
         "Packaged": "2026-04-10 14:27:17 UTC; davis",
         "Author": "Hadley Wickham [aut],\n  Lionel Henry [aut],\n  Davis Vaughan [aut, cre],\n  data.table team [cph] (Radix sort based on data.table's forder() and\n    their contribution to R's order()),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-11 06:20:03 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:27:17 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 17:08:52 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "vctrs",
+        "RemoteRef": "vctrs",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.7.3"
       }
     },
     "vipor": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "vipor",
         "Type": "Package",
@@ -3220,15 +3352,14 @@
         "RoxygenNote": "7.2.3",
         "NeedsCompilation": "no",
         "Packaged": "2023-12-16 03:56:56 UTC; scott",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-12-18 14:30:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-25 16:14:54 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:05:18 UTC; windows"
       }
     },
     "viridisLite": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "viridisLite",
         "Type": "Package",
@@ -3248,14 +3379,14 @@
         "NeedsCompilation": "no",
         "Packaged": "2026-02-03 20:55:07 UTC; simon",
         "Author": "Simon Garnier [aut, cre],\n  Noam Ross [ctb, cph],\n  Bob Rudis [ctb, cph],\n  Marco Sciaini [ctb, cph],\n  Antônio Pedro Camargo [ctb, cph],\n  Cédric Scherer [ctb, cph]",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-02-04 06:40:10 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:26 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:20 UTC; windows"
       }
     },
     "waiter": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "waiter",
         "Title": "Loading Screen for 'Shiny'",
@@ -3275,20 +3406,20 @@
         "Packaged": "2025-09-23 11:45:51 UTC; hornik",
         "Author": "John Coene [aut, cre],\n  Jinhwan Kim [ctb],\n  Victor Granda [ctb] (ORCID: <https://orcid.org/0000-0002-0469-1991>)",
         "Maintainer": "John Coene <jcoenep@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-09-23 12:02:29 UTC",
-        "Built": "R 4.6.0; ; 2026-05-09 05:24:02 UTC; unix",
+        "Built": "R 4.5.3; ; 2026-05-16 18:50:25 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "waiter",
         "RemoteRef": "waiter",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
         "RemoteSha": "0.2.5.1"
       }
     },
     "withr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "withr",
         "Title": "Run Code 'With' Temporarily Modified Global State",
@@ -3311,14 +3442,14 @@
         "Packaged": "2024-10-28 10:58:18 UTC; lionel",
         "Author": "Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Kirill Müller [aut],\n  Kevin Ushey [aut],\n  Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jennifer Bryan [ctb],\n  Richard Cotton [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-10-28 13:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:27 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:20 UTC; windows"
       }
     },
     "writexl": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "writexl",
         "Type": "Package",
@@ -3338,26 +3469,20 @@
         "Packaged": "2025-04-15 13:34:41 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  John McNamara [cph] (Author of libxlsxwriter (see AUTHORS and COPYRIGHT\n    files for details))",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-04-15 14:40:03 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-05-09 05:00:42 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17",
-        "RemoteType": "standard",
-        "RemotePkgRef": "writexl",
-        "RemoteRef": "writexl",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "1.5.4"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-04-14 01:29:25 UTC; windows",
+        "Archs": "x64"
       }
     },
     "xfun": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "xfun",
         "Type": "Package",
         "Title": "Supporting Functions for Packages Maintained by 'Yihui Xie'",
-        "Version": "0.57",
+        "Version": "0.58",
         "Authors@R": "c(\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\", \"cph\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\", URL = \"https://yihui.org\")),\n  person(\"Wush\", \"Wu\", role = \"ctb\"),\n  person(\"Daijiang\", \"Li\", role = \"ctb\"),\n  person(\"Xianying\", \"Tan\", role = \"ctb\"),\n  person(\"Salim\", \"Brüggemann\", role = \"ctb\", email = \"salim-b@pm.me\", comment = c(ORCID = \"0000-0002-5329-5987\")),\n  person(\"Christophe\", \"Dervieux\", role = \"ctb\"),\n  person()\n  )",
         "Description": "Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.",
         "Depends": "R (>= 3.2.0)",
@@ -3367,21 +3492,27 @@
         "URL": "https://github.com/yihui/xfun",
         "BugReports": "https://github.com/yihui/xfun/issues",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
         "VignetteBuilder": "litedown",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-03-19 17:27:02 UTC; yihui",
+        "Packaged": "2026-05-31 16:49:17 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>, URL: https://yihui.org),\n  Wush Wu [ctb],\n  Daijiang Li [ctb],\n  Xianying Tan [ctb],\n  Salim Brüggemann [ctb] (ORCID: <https://orcid.org/0000-0002-5329-5987>),\n  Christophe Dervieux [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
-        "Date/Publication": "2026-03-20 16:50:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:30 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_5"
+        "Repository": "CRAN",
+        "Date/Publication": "2026-06-01 05:10:03 UTC",
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-06-10 01:10:49 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "xfun",
+        "RemoteRef": "xfun",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.58"
       }
     },
     "xml2": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "xml2",
         "Title": "Parse XML",
@@ -3405,15 +3536,15 @@
         "Packaged": "2026-01-17 13:03:05 UTC; jeroen",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Jeroen Ooms [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Foundation [ctb] (Copy of R-project homepage cached as example)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-01-17 16:10:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:28:06 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_28"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:59:59 UTC; windows",
+        "Archs": "x64"
       }
     },
     "xtable": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "xtable",
         "Version": "1.8-8",
@@ -3428,18 +3559,17 @@
         "URL": "http://xtable.r-forge.r-project.org/",
         "Depends": "R (>= 2.10.0)",
         "License": "GPL (>= 2)",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "NeedsCompilation": "no",
         "Packaged": "2026-02-20 02:51:53 UTC; dsco0",
         "Author": "David B. Dahl [aut],\n  David Scott [aut, cre],\n  Charles Roosen [aut],\n  Arni Magnusson [aut],\n  Jonathan Swinton [aut],\n  Ajay Shah [ctb],\n  Arne Henningsen [ctb],\n  Benno Puetz [ctb],\n  Bernhard Pfaff [ctb],\n  Claudio Agostinelli [ctb],\n  Claudius Loehnert [ctb],\n  David Mitchell [ctb],\n  David Whiting [ctb],\n  Fernando da Rosa [ctb],\n  Guido Gay [ctb],\n  Guido Schulz [ctb],\n  Ian Fellows [ctb],\n  Jeff Laake [ctb],\n  John Walker [ctb],\n  Jun Yan [ctb],\n  Liviu Andronic [ctb],\n  Markus Loecher [ctb],\n  Martin Gubri [ctb],\n  Matthieu Stigler [ctb],\n  Robert Castelo [ctb],\n  Seth Falcon [ctb],\n  Stefan Edwards [ctb],\n  Sven Garbade [ctb],\n  Uwe Ligges [ctb]",
         "Date/Publication": "2026-02-22 11:20:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; ; 2026-04-24 05:26:30 UTC; unix"
+        "Built": "R 4.5.3; ; 2026-03-22 02:03:21 UTC; windows"
       }
     },
     "yaml": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Type": "Package",
         "Package": "yaml",
@@ -3460,15 +3590,15 @@
         "Packaged": "2025-12-08 16:53:07 UTC; hadleywickham",
         "Author": "Hadley Wickham [cre] (ORCID: <https://orcid.org/0000-0003-4757-117X>),\n  Shawn Garbett [ctb] (ORCID: <https://orcid.org/0000-0003-4079-5621>),\n  Jeremy Stephens [aut, ctb],\n  Kirill Simonov [aut],\n  Yihui Xie [ctb] (ORCID: <https://orcid.org/0000-0003-0645-5666>),\n  Zhuoer Dong [ctb],\n  Jeffrey Horner [ctb],\n  reikoch [ctb],\n  Will Beasley [ctb] (ORCID: <https://orcid.org/0000-0002-5613-5006>),\n  Brendan O'Connor [ctb],\n  Michael Quinn [ctb],\n  Charlie Gao [ctb],\n  Gregory R. Warnes [ctb],\n  Zhian N. Kamvar [ctb]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-10 07:00:01 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:30 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-22 02:03:33 UTC; windows",
+        "Archs": "x64"
       }
     },
     "yaml12": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "yaml12",
         "Title": "Fast 'YAML' 1.2 Parser and Formatter",
@@ -3492,21 +3622,21 @@
         "Packaged": "2025-12-03 19:56:58 UTC; tomasz",
         "Author": "Tomasz Kalinowski [aut, cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Authors of the dependency Rust crates [cph] (See inst/AUTHORS and\n    LICENSE.note for vendored Rust dependency authors and licenses.)",
         "Maintainer": "Tomasz Kalinowski <tomasz@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-12-11 15:50:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-05-08 20:39:20 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_28",
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-03-28 19:03:48 UTC; windows",
+        "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "yaml12",
         "RemoteRef": "yaml12",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.1.0"
       }
     },
     "yyjsonr": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "yyjsonr",
         "Type": "Package",
@@ -3529,15 +3659,21 @@
         "NeedsCompilation": "yes",
         "Packaged": "2026-04-05 05:10:02 UTC; mike",
         "Author": "Mike Cheng [aut, cre, cph],\n  Yao Yuan [aut, cph] (Author of bundled yyjson),\n  Murat Tasan [ctb] ('json_verbatim' handling)",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2026-04-05 06:40:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 05:26:30 UTC; unix",
-        "Platform": "x86_64-pc-linux-gnu-manylinux_2_17"
+        "Built": "R 4.5.3; x86_64-w64-mingw32; 2026-05-04 15:55:34 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "yyjsonr",
+        "RemoteRef": "yyjsonr",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.1.22"
       }
     },
     "zeallot": {
       "Source": "CRAN",
-      "Repository": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
+      "Repository": "https://cran.rstudio.com",
       "description": {
         "Package": "zeallot",
         "Type": "Package",
@@ -3557,18 +3693,241 @@
         "Packaged": "2025-05-22 07:55:46 UTC; nteetor",
         "Author": "Nathan Teetor [aut, cre],\n  Paul Teetor [ctb]",
         "Maintainer": "Nathan Teetor <nate@haufin.ch>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-05-27 10:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-05-09 04:59:40 UTC; unix",
+        "Built": "R 4.5.3; ; 2026-04-25 16:27:45 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "zeallot",
         "RemoteRef": "zeallot",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest/bin/linux/manylinux_2_28-x86_64/4.6",
-        "RemotePkgPlatform": "source",
+        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
         "RemoteSha": "0.2.0"
       }
     }
   },
-  "files": {},
+  "files": {
+    ".Rbuildignore": {
+      "checksum": "17f847933966777e7397760158d3dc05"
+    },
+    "app.R": {
+      "checksum": "cd8f4f810a6750de0e20420cd85749d5"
+    },
+    "DESCRIPTION": {
+      "checksum": "f3a7ee8306ef44c5cae908d6d9dfe532"
+    },
+    "inst/app/data/excel_dictionary.json": {
+      "checksum": "10c1f3ba35a58152dd950f16c5aed1b9"
+    },
+    "inst/app/data/mitigators.json": {
+      "checksum": "cf9534626e764ebb1e6afb4074b05e69"
+    },
+    "inst/app/data/providers.json": {
+      "checksum": "435e93aa39aead73e5afbae898b69446"
+    },
+    "inst/app/data/sites.json": {
+      "checksum": "ffc29ef7cf2858ed308df7503fe1eeb9"
+    },
+    "inst/app/data/tx-lookup.json": {
+      "checksum": "d96f2196c058efa6d6b92e987b3eaa43"
+    },
+    "inst/app/text/distribution_activity-distribution_notes.md": {
+      "checksum": "2b6e81121942ae04237397a07df7a27b"
+    },
+    "inst/app/text/distribution_beeswarm.md": {
+      "checksum": "665627914564e387584d59fab3dedadb"
+    },
+    "inst/app/text/distribution_s-curve.md": {
+      "checksum": "52847c6476592b477de7e9773254c662"
+    },
+    "inst/app/text/home_about.md": {
+      "checksum": "6809c0be8a275896c63b9909f71600e8"
+    },
+    "inst/app/text/home_app-notes.md": {
+      "checksum": "257b9fe0736a114798eb552ef3bfd2ba"
+    },
+    "inst/app/text/notes_beddays.md": {
+      "checksum": "54caefb0340f6039b6c812826114c4cb"
+    },
+    "inst/app/text/principal_impact_individual-change-factors.md": {
+      "checksum": "c5e2d8cb85b19022bcb193b0d77d3f39"
+    },
+    "inst/app/text/principal_impact_waterfall.md": {
+      "checksum": "19c4ed73510bc7e6bf11d152c929aec8"
+    },
+    "inst/app/www/app.css": {
+      "checksum": "f3e4c09783f050beebfc35a319f40df7"
+    },
+    "inst/app/www/favicon.ico": {
+      "checksum": "6e637acbaee9a91b5ea921c7fa2baf41"
+    },
+    "inst/golem-config.yml": {
+      "checksum": "2656b33d104d3a44c4ad25a0f093885e"
+    },
+    "inst/life_expectancy.rds": {
+      "checksum": "79fee045c0be360b170324d3fb6c1a69"
+    },
+    "inst/report-outputs.Rmd": {
+      "checksum": "4fed24db38b238069afce45e58553620"
+    },
+    "inst/report-parameters.Rmd": {
+      "checksum": "747834287190b4857b8563f4da2c5aaf"
+    },
+    "inst/sample_params.json": {
+      "checksum": "3c3b9e98f7edaaa2745af4de10ffc728"
+    },
+    "inst/sample_results.json": {
+      "checksum": "66150b0fe66144adb09e45c9b1d629a8"
+    },
+    "inst/sample_results/acuity.parquet": {
+      "checksum": "e05bae1b80886908564552c319b0cb8e"
+    },
+    "inst/sample_results/age.parquet": {
+      "checksum": "8e8e340b4e6d04ba3055631739098604"
+    },
+    "inst/sample_results/attendance_category.parquet": {
+      "checksum": "5c8670adc179d42a81bce48ad900fa18"
+    },
+    "inst/sample_results/avoided_activity.parquet": {
+      "checksum": "71c9bc9c51954d7a9b520529e54db44a"
+    },
+    "inst/sample_results/default.parquet": {
+      "checksum": "0cfdfd7b0a3a4bf41b4828ad93faf227"
+    },
+    "inst/sample_results/delivery_episode_in_spell.parquet": {
+      "checksum": "747340c20a313bdf00b92b1e27d09209"
+    },
+    "inst/sample_results/params.json": {
+      "checksum": "b26d1eb4bc6c182ac5a514897174e156"
+    },
+    "inst/sample_results/sex+age_group.parquet": {
+      "checksum": "41eb5defb5501a28f2a442d45f42a007"
+    },
+    "inst/sample_results/sex+tretspef_grouped.parquet": {
+      "checksum": "2e4ad33beac056d00754753d66354979"
+    },
+    "inst/sample_results/step_counts.parquet": {
+      "checksum": "9c2982d8ba4dad1c518cfaea68399b08"
+    },
+    "inst/sample_results/tretspef.parquet": {
+      "checksum": "49120bfa34fa69e9769246519c0f4ead"
+    },
+    "inst/sample_results/tretspef+los_group.parquet": {
+      "checksum": "dfda07559f8fe8be520946aee2723ca6"
+    },
+    "inst/sample_results/variants.json": {
+      "checksum": "46138713502e7e76504aa649acb1cd01"
+    },
+    "NAMESPACE": {
+      "checksum": "3701a97ee0788c13447e6e447d946af8"
+    },
+    "R/_disable_autoload.R": {
+      "checksum": "9d8f7f20e88b559c046ec1f59fe82cba"
+    },
+    "R/app_config.R": {
+      "checksum": "0e477fabef1e3a81177030cb4f497fd2"
+    },
+    "R/app_server.R": {
+      "checksum": "0330bcf8c11116fc5786158898f5fafd"
+    },
+    "R/app_ui.R": {
+      "checksum": "78eddf8a7c90f67aadf545c9b5353cc6"
+    },
+    "R/fct_create_data_cache.R": {
+      "checksum": "e6e5953102731f963c33187abf3a8492"
+    },
+    "R/fct_get_activity_type_pod_measure_options.R": {
+      "checksum": "ed0fb0773367c0f2fd57169b47c00de4"
+    },
+    "R/fct_get_data.R": {
+      "checksum": "74033e2c0161d9c74f8462a7e586465a"
+    },
+    "R/fct_gt_bar.R": {
+      "checksum": "7e662b2d6a99b74c157d7a08766d8582"
+    },
+    "R/fct_gt_theme.R": {
+      "checksum": "d58018d302bd8ac0ee27fd45c20a7798"
+    },
+    "R/fct_report.R": {
+      "checksum": "fc9531fdee4eb92619675be2133f028a"
+    },
+    "R/golem_utils_server.R": {
+      "checksum": "ba61edb61bd003757152cf23e7294c59"
+    },
+    "R/golem_utils_ui.R": {
+      "checksum": "c96081cbc3e47f0c50873fe72f818ba1"
+    },
+    "R/mod_info_downloads_helpers.R": {
+      "checksum": "b11774b9f70b0cd12012cf36ef3ab2d1"
+    },
+    "R/mod_info_downloads_server.R": {
+      "checksum": "2e11914511611e78634638790851689f"
+    },
+    "R/mod_info_downloads_ui.R": {
+      "checksum": "1026bf5fab999c7dce376267677c2f77"
+    },
+    "R/mod_info_home_server.R": {
+      "checksum": "b51ae10fe1e62a61f62b4265b7e4a5b2"
+    },
+    "R/mod_info_home_ui.R": {
+      "checksum": "863a26cd79fab9611cfb0cdd30675b8c"
+    },
+    "R/mod_info_params_fct_tables.R": {
+      "checksum": "973c0ceff4e3afb2dc75fd34c521de80"
+    },
+    "R/mod_info_params_server.R": {
+      "checksum": "809c21e8b8d163b842065b98fa8589cb"
+    },
+    "R/mod_info_params_ui.R": {
+      "checksum": "0cbf821f76c72363de09e585c6b442c6"
+    },
+    "R/mod_measure_selection_server.R": {
+      "checksum": "66aaf5cb0f53f69c4a0989485f551e18"
+    },
+    "R/mod_measure_selection_ui.R": {
+      "checksum": "ed0b5d014df588c4849e5f72508717cf"
+    },
+    "R/mod_model_core_activity_server.R": {
+      "checksum": "d65bcb44a2d3dc3e7773c6f4119ae754"
+    },
+    "R/mod_model_core_activity_ui.R": {
+      "checksum": "d8a33f0a38b42308849d18f7d70146d7"
+    },
+    "R/mod_model_results_distribution_server.R": {
+      "checksum": "e2859f771623d92b88a2bcb532266f2c"
+    },
+    "R/mod_model_results_distribution_ui.R": {
+      "checksum": "54d040e4a5ee9527a486d2559fbdebf2"
+    },
+    "R/mod_principal_change_factor_effects_server.R": {
+      "checksum": "1bd3cca6db5b230c757de841b9758910"
+    },
+    "R/mod_principal_change_factor_effects_ui.R": {
+      "checksum": "1f418858b05b6565ad217e74b7084c39"
+    },
+    "R/mod_principal_detailed_server.R": {
+      "checksum": "11efb30b5344ff3c5a45bec5e0935a22"
+    },
+    "R/mod_principal_detailed_ui.R": {
+      "checksum": "53b04dc1520b07f77bb6ffa7470fbe29"
+    },
+    "R/mod_principal_summary_los_server.R": {
+      "checksum": "c77283a3975fd7b2032e2bf505fbc03e"
+    },
+    "R/mod_principal_summary_los_ui.R": {
+      "checksum": "d08753d2916167d5c1ea385c7e10e88f"
+    },
+    "R/mod_principal_summary_server.R": {
+      "checksum": "77867adfbe53bdb9aaea2a50017d2d6d"
+    },
+    "R/mod_principal_summary_ui.R": {
+      "checksum": "c1fa269d1d60b3cde0b15017ab1739df"
+    },
+    "R/run_app.R": {
+      "checksum": "78936270a6140ca500b681a922c35829"
+    },
+    "R/ZZZ.R": {
+      "checksum": "1b05347e99e6558546afc6038341ed40"
+    }
+  },
   "users": null
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3713,7 +3713,7 @@
       "checksum": "cd8f4f810a6750de0e20420cd85749d5"
     },
     "DESCRIPTION": {
-      "checksum": "f3a7ee8306ef44c5cae908d6d9dfe532"
+      "checksum": "08a39a22612d5d8f43943b5f2da44cb2"
     },
     "inst/app/data/excel_dictionary.json": {
       "checksum": "10c1f3ba35a58152dd950f16c5aed1b9"


### PR DESCRIPTION
Forgot to do this in #436, so the deployed dev outputs app is borking.

* Pinned {reskit} to v1.0.1 (given use of `get_tpma_label_lookup()`, `get_detailed_pods()`, `get_tretspef_lookup()`).
* Regenerated the manifest file given dependency changes in #436.

We talked a bit about the first bullet; I'm thinking that we _should_ pin the reskit version for now.