### PR TITLE
Print message if ICF chart has no data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     markdown,
     plotly,
     purrr,
-    reskit (== 1.0.1),
+    reskit (== 1.0.2),
     rlang,
     rmarkdown,
     scales,

--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -21,14 +21,6 @@ pkgload::load_all(params$wd, quiet = TRUE)
 ```
 
 ```{r}
-#| label: chunk_vars
-#| echo: false
-
-icf_fig_height <- 7
-icf_font_size <- 10
-```
-
-```{r}
 #| label: site-selections
 #| echo: false
 
@@ -59,7 +51,7 @@ This report provides the outputs (tables and charts) from the selected model sce
 
 Note that some tables and charts won't be generated if there was insufficient data to produce them, given the combination of trust and site selections (if any).
 
-This document is produced dynamically and so plots may not be produced at optimal size. 
+This document is produced dynamically and so plots may not be produced at optimal size.
 Please [contact The Strategy Unit Data Science team](mailto:mlcsu.su.datascience@nhs.net) if this is a problem.
 
 See [the project information site](https://connect.strategyunitwm.nhs.uk/nhp/project_information) for an overview of the model and its methodology.
@@ -132,42 +124,51 @@ The results should be regarded as rough, high-level estimates of the number of r
 ```{r}
 #| label: pp-impact-of-changes-setup
 
-possibly_compile_change_factor_data <-
-  purrr::possibly(
-    reskit::compile_change_factor_data,
-    "Insufficient data"
-  )
+# Stopgap values so the ICF chart content is visible, see:
+# https://github.com/The-Strategy-Unit/nhp_outputs/issues/427
+icf_fig_height <- 7
+icf_font_size <- 10
 
-possibly_compile_indiv_change_factor_data <-
-  purrr::possibly(
-    reskit::compile_indiv_change_factor_data,
-    "Insufficient data"
-  )
+# Return a useful message if the data is empty, see:
+# https://github.com/The-Strategy-Unit/nhp_outputs/issues/441
+make_icf_chart_or_msg <- function(icf_data) {
+  if (nrow(icf_data) == 0) {
+    "Insufficient information to produce this chart."
+  } else {
+    icf_data |>
+      reskit::make_individual_cf_plot() +
+      ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
+  }
+}
 ```
 
 ### Inpatients
 
 #### Bed days
 
+##### Overall change-factors
+
 ```{r}
 #| label: pp-impact-of-changes-overall-ip-bed-days
 
 params$r$results |>
-  possibly_compile_change_factor_data(
+  reskit::compile_change_factor_data(
     measure = "beddays",
     activity_type = "ip",
     sites = params$sites,
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_overall_cf_plot()
+    reskit::make_overall_cf_plot()
 ```
+
+##### Individual change-factors
 
 ```{r, fig.height=icf_fig_height}
 #| label: pp-impact-of-changes-individual-ip-bed-days
 
 params$r$results |>
-  possibly_compile_indiv_change_factor_data(
+  reskit::compile_indiv_change_factor_data(
     measure = "beddays",
     activity_type = "ip",
     sites = params$sites,
@@ -175,17 +176,18 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot() +
-  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
+    make_icf_chart_or_msg()
 ```
 
 #### Admissions
+
+##### Overall change-factors
 
 ```{r}
 #| label: pp-impact-of-changes-overall-ip-admissions
 
 params$r$results |>
-  possibly_compile_change_factor_data(
+  reskit::compile_change_factor_data(
     measure = "admissions",
     activity_type = "ip",
     sites = params$sites,
@@ -195,11 +197,13 @@ params$r$results |>
   reskit::make_overall_cf_plot()
 ```
 
+##### Individual change-factors
+
 ```{r, fig.height=icf_fig_height}
 #| label: pp-impact-of-changes-individual-ip-admissions
 
 params$r$results |>
-  possibly_compile_indiv_change_factor_data(
+  reskit::compile_indiv_change_factor_data(
     measure = "admissions",
     activity_type = "ip",
     sites = params$sites,
@@ -207,19 +211,20 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot() +
-  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
+    make_icf_chart_or_msg()
 ```
 
 ### Outpatients
 
 #### Attendances
 
+##### Overall change-factors
+
 ```{r}
 #| label: pp-impact-of-changes-overall-op-attendances
 
 params$r$results |>
-  possibly_compile_change_factor_data(
+  reskit::compile_change_factor_data(
     measure = "attendances",
     activity_type = "op",
     sites = params$sites,
@@ -228,12 +233,14 @@ params$r$results |>
   ) |>
   reskit::make_overall_cf_plot()
 ```
+
+##### Individual change-factors
 
 ```{r, fig.height=icf_fig_height}
 #| label: pp-impact-of-changes-individual-op-attendances
 
 params$r$results |>
-  possibly_compile_indiv_change_factor_data(
+  reskit::compile_indiv_change_factor_data(
     measure = "attendances",
     activity_type = "op",
     sites = params$sites,
@@ -241,17 +248,18 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot() +
-  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
+    make_icf_chart_or_msg()
 ```
 
 #### Tele-attendances
+
+##### Overall change-factors
 
 ```{r}
 #| label: pp-impact-of-changes-overall-op-tele-attendances
 
 params$r$results |>
-  possibly_compile_change_factor_data(
+  reskit::compile_change_factor_data(
     measure = "tele_attendances",
     activity_type = "op",
     sites = params$sites,
@@ -261,11 +269,13 @@ params$r$results |>
   reskit::make_overall_cf_plot()
 ```
 
+##### Individual change-factors
+
 ```{r, fig.height=icf_fig_height}
 #| label: pp-impact-of-changes-individual-op-tele-attendances
 
 params$r$results |>
-  possibly_compile_indiv_change_factor_data(
+  reskit::compile_indiv_change_factor_data(
     measure = "tele_attendances",
     activity_type = "op",
     sites = params$sites,
@@ -273,19 +283,20 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot() +
-  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
+    make_icf_chart_or_msg()
 ```
 
 ### A&E
 
 #### Arrivals
 
+##### Overall change-factors
+
 ```{r}
 #| label: pp-impact-of-changes-overall-aae-arrivals
 
 params$r$results |>
-  possibly_compile_change_factor_data(
+  reskit::compile_change_factor_data(
     measure = "arrivals",
     activity_type = "aae",
     sites = params$sites,
@@ -295,11 +306,13 @@ params$r$results |>
   reskit::make_overall_cf_plot()
 ```
 
+##### Individual change-factors
+
 ```{r, fig.height=icf_fig_height}
 #| label: pp-impact-of-changes-individual-aae-arrivals
 
 params$r$results |>
-  possibly_compile_indiv_change_factor_data(
+  reskit::compile_indiv_change_factor_data(
     measure = "arrivals",
     activity_type = "aae",
     sites = params$sites,
@@ -307,8 +320,7 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-  reskit::make_individual_cf_plot() +
-  ggplot2::theme(text = ggplot2::element_text(size = icf_font_size))
+    make_icf_chart_or_msg()
 ```
 
 ## Activity in detail

--- a/inst/report-outputs.Rmd
+++ b/inst/report-outputs.Rmd
@@ -159,7 +159,7 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-    reskit::make_overall_cf_plot()
+  reskit::make_overall_cf_plot()
 ```
 
 ##### Individual change-factors
@@ -176,7 +176,7 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-    make_icf_chart_or_msg()
+  make_icf_chart_or_msg()
 ```
 
 #### Admissions
@@ -211,7 +211,7 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-    make_icf_chart_or_msg()
+  make_icf_chart_or_msg()
 ```
 
 ### Outpatients
@@ -248,7 +248,7 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-    make_icf_chart_or_msg()
+  make_icf_chart_or_msg()
 ```
 
 #### Tele-attendances
@@ -283,7 +283,7 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-    make_icf_chart_or_msg()
+  make_icf_chart_or_msg()
 ```
 
 ### A&E
@@ -320,7 +320,7 @@ params$r$results |>
     tpma_lookup = reskit::get_tpma_label_lookup(),
     pod_lookup = reskit::get_principal_pods()
   ) |>
-    make_icf_chart_or_msg()
+  make_icf_chart_or_msg()
 ```
 
 ## Activity in detail

--- a/manifest.json
+++ b/manifest.json
@@ -3713,7 +3713,7 @@
       "checksum": "cd8f4f810a6750de0e20420cd85749d5"
     },
     "DESCRIPTION": {
-      "checksum": "08a39a22612d5d8f43943b5f2da44cb2"
+      "checksum": "3f03e02b260aa8c1754fe5caf0b7fe01"
     },
     "inst/app/data/excel_dictionary.json": {
       "checksum": "10c1f3ba35a58152dd950f16c5aed1b9"
@@ -3767,7 +3767,7 @@
       "checksum": "79fee045c0be360b170324d3fb6c1a69"
     },
     "inst/report-outputs.Rmd": {
-      "checksum": "4fed24db38b238069afce45e58553620"
+      "checksum": "ccf1e4b7a62059acd5ed533e83685b97"
     },
     "inst/report-parameters.Rmd": {
       "checksum": "747834287190b4857b8563f4da2c5aaf"
@@ -3779,42 +3779,81 @@
       "checksum": "66150b0fe66144adb09e45c9b1d629a8"
     },
     "inst/sample_results/acuity.parquet": {
-      "checksum": "e05bae1b80886908564552c319b0cb8e"
+      "checksum": "1fd71c228cdbaf93f5ddc40f03b997d6"
     },
     "inst/sample_results/age.parquet": {
-      "checksum": "8e8e340b4e6d04ba3055631739098604"
+      "checksum": "0f2c08d517f2ebfbf298cce7de1377f6"
     },
     "inst/sample_results/attendance_category.parquet": {
-      "checksum": "5c8670adc179d42a81bce48ad900fa18"
+      "checksum": "5064334124f9c326344653194ba325a6"
     },
     "inst/sample_results/avoided_activity.parquet": {
-      "checksum": "71c9bc9c51954d7a9b520529e54db44a"
+      "checksum": "cd8aa3adcc6bf4a2ef201aef4275be05"
     },
     "inst/sample_results/default.parquet": {
-      "checksum": "0cfdfd7b0a3a4bf41b4828ad93faf227"
+      "checksum": "d832e393d39be0ecd897afb800578187"
     },
     "inst/sample_results/delivery_episode_in_spell.parquet": {
-      "checksum": "747340c20a313bdf00b92b1e27d09209"
+      "checksum": "839e734aef2057c1b09d4b83c77dfeb4"
     },
     "inst/sample_results/params.json": {
-      "checksum": "b26d1eb4bc6c182ac5a514897174e156"
+      "checksum": "a4a03416daeb4f716ff3cf1823c5ebef"
     },
     "inst/sample_results/sex+age_group.parquet": {
-      "checksum": "41eb5defb5501a28f2a442d45f42a007"
+      "checksum": "c9b4e915a84e5c4e5986aac2245a5c23"
     },
     "inst/sample_results/sex+tretspef_grouped.parquet": {
-      "checksum": "2e4ad33beac056d00754753d66354979"
+      "checksum": "ea75f0ddd023e622e3a518aebacdd56a"
     },
     "inst/sample_results/step_counts.parquet": {
-      "checksum": "9c2982d8ba4dad1c518cfaea68399b08"
+      "checksum": "11974af0268c5cad3596031d80b09ba0"
     },
     "inst/sample_results/tretspef.parquet": {
-      "checksum": "49120bfa34fa69e9769246519c0f4ead"
+      "checksum": "2a3410391cba6f730a5f44efceda84e1"
     },
     "inst/sample_results/tretspef+los_group.parquet": {
-      "checksum": "dfda07559f8fe8be520946aee2723ca6"
+      "checksum": "ce34023c0101873101a5dbb6e949e47d"
     },
     "inst/sample_results/variants.json": {
+      "checksum": "46138713502e7e76504aa649acb1cd01"
+    },
+    "inst/sample_results_old/acuity.parquet": {
+      "checksum": "e05bae1b80886908564552c319b0cb8e"
+    },
+    "inst/sample_results_old/age.parquet": {
+      "checksum": "8e8e340b4e6d04ba3055631739098604"
+    },
+    "inst/sample_results_old/attendance_category.parquet": {
+      "checksum": "5c8670adc179d42a81bce48ad900fa18"
+    },
+    "inst/sample_results_old/avoided_activity.parquet": {
+      "checksum": "71c9bc9c51954d7a9b520529e54db44a"
+    },
+    "inst/sample_results_old/default.parquet": {
+      "checksum": "0cfdfd7b0a3a4bf41b4828ad93faf227"
+    },
+    "inst/sample_results_old/delivery_episode_in_spell.parquet": {
+      "checksum": "747340c20a313bdf00b92b1e27d09209"
+    },
+    "inst/sample_results_old/params.json": {
+      "checksum": "b26d1eb4bc6c182ac5a514897174e156"
+    },
+    "inst/sample_results_old/sex+age_group.parquet": {
+      "checksum": "41eb5defb5501a28f2a442d45f42a007"
+    },
+    "inst/sample_results_old/sex+tretspef_grouped.parquet": {
+      "checksum": "2e4ad33beac056d00754753d66354979"
+    },
+    "inst/sample_results_old/step_counts.parquet": {
+      "checksum": "9c2982d8ba4dad1c518cfaea68399b08"
+    },
+    "inst/sample_results_old/tretspef.parquet": {
+      "checksum": "49120bfa34fa69e9769246519c0f4ead"
+    },
+    "inst/sample_results_old/tretspef+los_group.parquet": {
+      "checksum": "dfda07559f8fe8be520946aee2723ca6"
+    },
+    "inst/sample_results_old/variants.json": {
       "checksum": "46138713502e7e76504aa649acb1cd01"
     },
     "NAMESPACE": {


### PR DESCRIPTION
Close #441.

* Handled zero-row ICF data with a printed message.
* Moved all impact-of-changes code into one setup chunk.
* Added headings for overall and individual change-factor charts.
* Removed `purrr::possibly()` calls for now (there should always be an overall- and individual-change-factor object).

Have marked you for review, @francisbarton, given that this solves an error we saw in [pre-release QA for v5.2](https://github.com/The-Strategy-Unit/nhp_planning/issues/633#issuecomment-4780465435). This will do for now.